### PR TITLE
Don't treat TestUtils as a test case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,16 @@
           </archive>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
+        <configuration>
+          <excludes>
+            <exclude>**/TestUtils.java</exclude>
+          </excludes>
+        </configuration>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
`mvn package` was blowing up for me because surefire was trying to run TestUtils as a junit test.