### PR TITLE
Feature/39 whitespace control

### DIFF
--- a/src/main/antlr3/liqp/parser/Liquid.g
+++ b/src/main/antlr3/liqp/parser/Liquid.g
@@ -90,8 +90,16 @@ tokens {
 }
 
 @lexer::members {
+
+  private boolean stripSpacesAroundTags = false;
+
   private boolean inTag = false;
   private boolean inRaw = false;
+
+  public LiquidLexer(boolean stripSpacesAroundTags, CharStream input) {
+    this(input, new RecognizerSharedState());
+    this.stripSpacesAroundTags = stripSpacesAroundTags;
+  }
 
   private boolean openStripTagAhead() {
 
@@ -101,7 +109,9 @@ tokens {
       indexLA++;
     }
 
-    return input.LA(indexLA) == '{' && (input.LA(indexLA + 1) == '{' || input.LA(indexLA + 1) == '\u0025') && input.LA(indexLA + 2) == '-';
+    return stripSpacesAroundTags
+        ? input.LA(indexLA) == '{' && (input.LA(indexLA + 1) == '{' || input.LA(indexLA + 1) == '\u0025')
+        : input.LA(indexLA) == '{' && (input.LA(indexLA + 1) == '{' || input.LA(indexLA + 1) == '\u0025') && input.LA(indexLA + 2) == '-';
   }
 
   private boolean openRawEndTagAhead() {
@@ -399,6 +409,11 @@ other_than_tag_end
  ;
 
 /* lexer rules */
+OutStartDefaultStrip : {stripSpacesAroundTags}?=> WhitespaceChar* '{{' {inTag=true; $type=OutStart;};
+OutEndDefaultStrip   : {stripSpacesAroundTags}?=> '}}' WhitespaceChar* {inTag=false; $type=OutEnd;};
+TagStartDefaultStrip : {stripSpacesAroundTags}?=> WhitespaceChar* '{%' {inTag=true; $type=TagStart;};
+TagEndDefaultStrip   : {stripSpacesAroundTags}?=> '%}' WhitespaceChar* {inTag=false; $type=TagEnd;};
+
 OutStartStrip : WhitespaceChar* '{{-' {inTag=true; $type=OutStart;};
 OutEndStrip   : '-}}' WhitespaceChar* {inTag=false; $type=OutEnd;};
 TagStartStrip : WhitespaceChar* '{%-' {inTag=true; $type=TagStart;};

--- a/src/main/java/liqp/ParseSettings.java
+++ b/src/main/java/liqp/ParseSettings.java
@@ -1,0 +1,39 @@
+package liqp;
+
+import liqp.parser.Flavor;
+
+public class ParseSettings {
+
+    public final Flavor flavor;
+    public final boolean stripSpacesAroundTags;
+
+    public static class Builder {
+
+        Flavor flavor;
+        boolean stripSpacesAroundTags;
+
+        public Builder() {
+            this.flavor = Flavor.LIQUID;
+            this.stripSpacesAroundTags = false;
+        }
+
+        public Builder withFlavor(Flavor flavor) {
+            this.flavor = flavor;
+            return this;
+        }
+
+        public Builder withStripSpaceAroundTags(boolean stripSpacesAroundTags) {
+            this.stripSpacesAroundTags = stripSpacesAroundTags;
+            return this;
+        }
+
+        public ParseSettings build() {
+            return new ParseSettings(this.flavor, this.stripSpacesAroundTags);
+        }
+    }
+
+    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags) {
+        this.flavor = flavor;
+        this.stripSpacesAroundTags = stripSpacesAroundTags;
+    }
+}

--- a/src/test/java/liqp/TestUtils.java
+++ b/src/test/java/liqp/TestUtils.java
@@ -7,6 +7,7 @@ import liqp.parser.LiquidLexer;
 import liqp.parser.LiquidParser;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
+import org.antlr.runtime.Token;
 import org.antlr.runtime.tree.CommonTree;
 import org.antlr.runtime.tree.CommonTreeNodeStream;
 
@@ -28,7 +29,7 @@ public final class TestUtils {
      */
     public static LNode getNode(String source, String rule) throws Exception {
 
-        LiquidLexer lexer = new LiquidLexer(new ANTLRStringStream("{{" + source + "}}"));
+        LiquidLexer lexer = new LiquidLexer(new ANTLRStringStream("{{ " + source + " }}"));
         LiquidParser parser =  new LiquidParser(new CommonTokenStream(lexer));
 
         CommonTree root = (CommonTree)parser.parse().getTree();
@@ -39,5 +40,22 @@ public final class TestUtils {
         Method method = walker.getClass().getMethod(rule);
 
         return (LNode)method.invoke(walker);
+    }
+
+    public static void dumpTokens(String source) {
+
+        LiquidLexer lexer = new LiquidLexer(new ANTLRStringStream(source));
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        tokenStream.fill();
+
+        for (Token t : tokenStream.getTokens()) {
+            System.out.printf("%-20s '%s'\n",
+                    t.getType() == -1 ? "EOF" : LiquidParser.tokenNames[t.getType()],
+                    t.getText().replace("\n", "\\n"));
+        }
+    }
+
+    public static void main(String[] args) {
+        dumpTokens("a  \n  {%-");
     }
 }

--- a/src/test/java/liqp/tags/WhitespaceControlTest.java
+++ b/src/test/java/liqp/tags/WhitespaceControlTest.java
@@ -1,0 +1,82 @@
+package liqp.tags;
+
+import liqp.Template;
+import org.antlr.runtime.RecognitionException;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+// All output in this test class is tested against Ruby 2.3.1 and Liquid 4.0.0
+public class WhitespaceControlTest {
+
+    @Test
+    public void noStrip() throws RecognitionException {
+
+        String source = "a  \n  {% assign letter = 'b' %}  \n{{ letter }}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("a..\n....\nb\n..c"));
+    }
+
+    @Test
+    public void oneLhsStrip() throws RecognitionException {
+
+        String source = "a  \n  {%- assign letter = 'b' %}  \n{{ letter }}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("a..\nb\n..c"));
+    }
+
+    @Test
+    public void oneRhsStrip() throws RecognitionException {
+
+        String source = "a  \n  {% assign letter = 'b' -%}  \n{{ letter }}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("a..\n..b\n..c"));
+    }
+
+    @Test
+    public void oneBothStrip() throws RecognitionException {
+
+        String source = "a  \n  {%- assign letter = 'b' -%}  \n{{ letter }}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("ab\n..c"));
+    }
+
+    @Test
+    public void twoLhsStrip() throws RecognitionException {
+
+        String source = "a  \n  {%- assign letter = 'b' %}  \n{{- letter }}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("ab\n..c"));
+    }
+
+    @Test
+    public void twoRhsStrip() throws RecognitionException {
+
+        String source = "a  \n  {% assign letter = 'b' -%}  \n{{ letter -}}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("a..\n..bc"));
+    }
+
+    @Test
+    public void allStrip() throws RecognitionException {
+
+        String source = "a  \n  {%- assign letter = 'b' -%}  \n{{- letter -}}\n  c";
+        Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("abc"));
+    }
+}

--- a/src/test/java/liqp/tags/WhitespaceControlTest.java
+++ b/src/test/java/liqp/tags/WhitespaceControlTest.java
@@ -1,5 +1,6 @@
 package liqp.tags;
 
+import liqp.ParseSettings;
 import liqp.Template;
 import org.antlr.runtime.RecognitionException;
 import org.junit.Test;
@@ -75,6 +76,17 @@ public class WhitespaceControlTest {
 
         String source = "a  \n  {%- assign letter = 'b' -%}  \n{{- letter -}}\n  c";
         Template template = Template.parse(source);
+        String rendered = String.valueOf(template.render().replace(' ', '.'));
+
+        assertThat(rendered, is("abc"));
+    }
+
+    @Test
+    public void defaultStrip() throws RecognitionException {
+
+        String source = "a  \n  {% assign letter = 'b' %}  \n{{ letter }}\n  c";
+        ParseSettings settings = new ParseSettings.Builder().withStripSpaceAroundTags(true).build();
+        Template template = Template.parse(source, settings);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("abc"));


### PR DESCRIPTION
Added:

- support for [whitespace control](https://shopify.github.io/liquid/basics/whitespace/): `{{- ... -}}` and `{{%- ... - %}`
- the option to always strip spaces around tags via a `ParseSettings` instance (this now also houses the parse `Flavor`)