### PR TITLE
Bug/custom tag parameters as string

### DIFF
--- a/src/main/antlr3/liqp/nodes/LiquidWalker.g
+++ b/src/main/antlr3/liqp/nodes/LiquidWalker.g
@@ -220,16 +220,15 @@ continue_tag returns [LNode node]
  : Continue {$node = new AtomNode(Tag.Statement.CONTINUE);}
  ;
 
-
 custom_tag returns [LNode node]
 @init{List<LNode> expressions = new ArrayList<LNode>();}
- : ^(CUSTOM_TAG Id (expr {expressions.add($expr.node);})*)
+ : ^(CUSTOM_TAG Id Str? {expressions.add(new AtomNode($Str.text));})
     {$node = new TagNode($Id.text, tags.get($Id.text), expressions.toArray(new LNode[expressions.size()]));}
  ;
 
 custom_tag_block returns [LNode node]
 @init{List<LNode> expressions = new ArrayList<LNode>();}
- : ^(CUSTOM_TAG_BLOCK Id (expr {expressions.add($expr.node);})* block {expressions.add($block.node);})
+ : ^(CUSTOM_TAG_BLOCK Id Str? {expressions.add(new AtomNode($Str.text));} block {expressions.add($block.node);})
     {$node = new TagNode($Id.text, tags.get($Id.text), expressions.toArray(new LNode[expressions.size()]));}
  ;
 

--- a/src/main/antlr3/liqp/parser/Liquid.g
+++ b/src/main/antlr3/liqp/parser/Liquid.g
@@ -182,8 +182,8 @@ tag
  ;
 
 custom_tag
- : (TagStart Id (expr (Comma expr)*)? TagEnd -> ^(CUSTOM_TAG Id expr*))
-   ((custom_tag_block)=> custom_tag_block    -> ^(CUSTOM_TAG_BLOCK Id expr* custom_tag_block))?
+ : (TagStart Id custom_tag_parameters? TagEnd -> ^(CUSTOM_TAG Id custom_tag_parameters?))
+   ((custom_tag_block)=> custom_tag_block     -> ^(CUSTOM_TAG_BLOCK Id custom_tag_parameters? custom_tag_block))?
  ;
 
 custom_tag_block
@@ -401,6 +401,10 @@ index
  ;
 
 file_name_as_str
+ : other_than_tag_end -> Str[$text]
+ ;
+
+custom_tag_parameters
  : other_than_tag_end -> Str[$text]
  ;
 

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -270,9 +270,12 @@ public class Template {
         try {
             return future.get(this.protectionSettings.maxRenderTimeMillis, TimeUnit.MILLISECONDS);
         }
-        catch (Throwable t) {
+        catch (TimeoutException e) {
             throw new RuntimeException("exceeded the max amount of time (" +
                     this.protectionSettings.maxRenderTimeMillis + " ms.)");
+        }
+        catch (Throwable t) {
+            throw new RuntimeException("Oops, something unexpected happened: ", t);
         }
     }
 


### PR DESCRIPTION
Fix for custom tag parameters being previously separated by commas. Now all (optional) parameters are 1 string (as per the Liquid specs).

Below an example of how it must be used:

```java
public class Test {

    public static void main(String[] args) {

        String source = "{% highlight shell linenos %}\n" +
                "cd /opt/dev/myproject\n" +
                "mvn clean install\n" +
                "{% endhighlight %}";

        String rendered = Template
                .parse(source)
                .with(new Highlight())
                .render();

        System.out.println(rendered);
    }
}

class Highlight extends Tag {

    public Highlight() {
        super("highlight");
    }

    @Override
    public Object render(TemplateContext context, LNode... nodes) {

        // parameters will be null when no parameters are present
        Object parameters = nodes[0].render(context);

        // The inner contents of the tag will always be in nodes[1]
        String sourceCode = super.asString(nodes[1].render(context));

        System.out.printf("parameters=`%s`\nsourceCode=`%s`\n", parameters, sourceCode);

        return "TODO";
    }
}
```

Running the code above will print:

```text
parameters=`shell linenos`
sourceCode=`
cd /opt/dev/myproject
mvn clean install
`
TODO
```

Also see: https://github.com/bkiers/Liqp/issues/42
