### PR TITLE
Allow filters to have access to the template context

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ System.out.println(rendered);
     hi tobi
 */
 ```
-The context provided as a parameter to `render(...)` can be:
+The template variables provided as parameters to `render(...)` can be:
 
 * a [varargs](http://docs.oracle.com/javase/1.5.0/docs/guide/language/varargs.html) where 
   the 0<sup>th</sup>, 2<sup>nd</sup>, 4<sup>th</sup>, ... indexes must be `String` literals
@@ -177,7 +177,7 @@ String rendered = template.render(); // no value for "name"
 
 ### 2.1 Custom filters
 
-Let's say you want to create a custom filters, called `b`, that changes a string like 
+Let's say you want to create a custom filter, called `b`, that changes a string like 
 `*text*` to `<strong>text</strong>`.
 
 You can do that as follows:
@@ -262,6 +262,7 @@ System.out.println(rendered);
     15.0
 */
 ```
+In short, override one of the `apply()` methods of the `Filter` class to create your own custom filter behaviour.
 
 ### 2.2 Custom tags
 

--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -43,7 +43,7 @@ public class TemplateContext {
 
     public boolean containsKey(String key) {
 
-        if (this.containsKey(key)) {
+        if (this.variables.containsKey(key)) {
             return true;
         }
 

--- a/src/main/java/liqp/filters/Filter.java
+++ b/src/main/java/liqp/filters/Filter.java
@@ -1,6 +1,7 @@
 package liqp.filters;
 
 import liqp.LValue;
+import liqp.TemplateContext;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -89,7 +90,28 @@ public abstract class Filter extends LValue {
      *
      * @return the result of the filter.
      */
-    public abstract Object apply(Object value, Object... params);
+    public Object apply(Object value, Object... params) {
+
+        // Default "no-op" filter.
+        return value;
+    }
+
+    /**
+     * Applies the filter on the 'value', with the given 'context'.
+     *
+     * @param value
+     *         the string value `AAA` in: `{{ 'AAA' | f:1,2,3 }}`
+     * @param context
+     *         the template context.
+     * @param params
+     *         the values [1, 2, 3] in: `{{ 'AAA' | f:1,2,3 }}`
+     *
+     * @return the result of the filter.
+     */
+    public Object apply(Object value, TemplateContext context, Object... params) {
+
+        return apply(value, params);
+    }
 
     /**
      * Check the number of parameters and throws an exception if needed.
@@ -100,7 +122,8 @@ public abstract class Filter extends LValue {
      *         the expected number of parameters.
      */
     public final void checkParams(Object[] params, int expected) {
-        if(params == null || params.length != expected) {
+
+        if (params == null || params.length != expected) {
             throw new RuntimeException("Liquid error: wrong number of arguments (" +
                     (params.length + 1) + " for " + (expected + 1) + ")");
         }

--- a/src/main/java/liqp/nodes/FilterNode.java
+++ b/src/main/java/liqp/nodes/FilterNode.java
@@ -31,7 +31,7 @@ public class FilterNode implements LNode {
             paramValues.add(node.render(context));
         }
 
-        return filter.apply(value, paramValues.toArray(new Object[paramValues.size()]));
+        return filter.apply(value, context, paramValues.toArray(new Object[paramValues.size()]));
     }
 
     @Override


### PR DESCRIPTION
Hi Bart, thanks for creating this Liquid library for Java!

Two things in my PR:

1. A fix to an infinite loop inside `TemplateContext::containsKey`.

2. Modification to `Filter` to allow the `TemplateContext` to be passed to the `apply()` method. Backwards compatibility was maintained (i.e. no existing filter implementations shall be broken).