### PR TITLE
Implement not operator in expressions

### DIFF
--- a/src/main/antlr3/liqp/nodes/LiquidWalker.g
+++ b/src/main/antlr3/liqp/nodes/LiquidWalker.g
@@ -251,6 +251,7 @@ assignment returns [TagNode node]
 expr returns [LNode node]
  : ^(Or a=expr b=expr)       {$node = new OrNode($a.node, $b.node);}
  | ^(And a=expr b=expr)      {$node = new AndNode($a.node, $b.node);}
+ | ^(Not a=expr)             {$node = new NotNode($a.node);}
  | ^(Eq a=expr b=expr)       {$node = new EqNode($a.node, $b.node);}
  | ^(NEq a=expr b=expr)      {$node = new NEqNode($a.node, $b.node);}
  | ^(LtEq a=expr b=expr)     {$node = new LtEqNode($a.node, $b.node);}

--- a/src/main/antlr3/liqp/parser/Liquid.g
+++ b/src/main/antlr3/liqp/parser/Liquid.g
@@ -319,7 +319,11 @@ or_expr
  ;
 
 and_expr
- : contains_expr (And^ contains_expr)*
+ : not_expr (And^ not_expr)*
+ ;
+
+not_expr
+ : (Not^)? contains_expr
  ;
 
 contains_expr
@@ -383,6 +387,7 @@ id2
  | In           -> Id[$In.text]
  | And          -> Id[$And.text]
  | Or           -> Id[$Or.text]
+ | Not          -> Id[$Not.text]
  | TableStart   -> Id[$TableStart.text]
  | TableEnd     -> Id[$TableEnd.text]
  | Assign       -> Id[$Assign.text]
@@ -480,6 +485,7 @@ Id
      else if($text.equals("in"))           $type = In;
      else if($text.equals("and"))          $type = And;
      else if($text.equals("or"))           $type = Or;
+     else if($text.equals("not"))          $type = Not;
      else if($text.equals("tablerow"))     $type = TableStart;
      else if($text.equals("endtablerow"))  $type = TableEnd;
      else if($text.equals("assign"))       $type = Assign;
@@ -533,6 +539,7 @@ fragment ForEnd : 'ForEnd';
 fragment In : 'In';
 fragment And : 'And';
 fragment Or : 'Or';
+fragment Not : 'Not';
 fragment TableStart : 'TableStart';
 fragment TableEnd : 'TableEnd';
 fragment Assign : 'Assign';

--- a/src/main/java/liqp/nodes/NotNode.java
+++ b/src/main/java/liqp/nodes/NotNode.java
@@ -1,0 +1,22 @@
+package liqp.nodes;
+
+import liqp.LValue;
+import liqp.TemplateContext;
+
+class NotNode extends LValue implements LNode {
+
+    private LNode rhs;
+
+    public NotNode(LNode rhs) {
+        this.rhs = rhs;
+    }
+
+    @Override
+    public Object render(TemplateContext context) {
+
+        Object a = rhs.render(context);
+
+        return !(super.asBoolean(a));
+
+    }
+}

--- a/src/test/java/liqp/nodes/NotNodeTest.java
+++ b/src/test/java/liqp/nodes/NotNodeTest.java
@@ -1,0 +1,34 @@
+package liqp.nodes;
+
+import liqp.Template;
+import org.antlr.runtime.RecognitionException;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class NotNodeTest {
+
+    @Test
+    public void applyTest() throws RecognitionException {
+
+        String[][] tests = {
+                {"{% if not true %}TRUE{% else %}FALSE{% endif %}", "FALSE"},
+                {"{% if not false %}TRUE{% else %}FALSE{% endif %}", "TRUE"},
+                {"{% if false or not true %}TRUE{% else %}FALSE{% endif %}", "FALSE"},
+                {"{% if not false and true %}TRUE{% else %}FALSE{% endif %}", "TRUE"},
+                {"{% if nil or not true %}TRUE{% else %}FALSE{% endif %}", "FALSE"},
+                {"{% if nil or not false %}TRUE{% else %}FALSE{% endif %}", "TRUE"},
+                {"{% if '' and not false %}TRUE{% else %}FALSE{% endif %}", "TRUE"},
+                {"{% if '' and not true %}TRUE{% else %}FALSE{% endif %}", "FALSE"},
+        };
+
+        for (String[] test : tests) {
+
+            Template template = Template.parse(test[0]);
+            String rendered = String.valueOf(template.render());
+
+            assertThat(rendered, is(test[1]));
+        }
+    }
+}


### PR DESCRIPTION
It would be nice to have not operator, the following looks weird to me:
`{% if propertyOne or propertyTwo == false %}`

This syntax is more natural:
`{% if propertyOne or not propertyTwo %}`

What do you think?