### PR TITLE
And/Or operators are checked in order from right to left.

### DIFF
--- a/src/main/antlr3/liqp/parser/Liquid.g
+++ b/src/main/antlr3/liqp/parser/Liquid.g
@@ -311,15 +311,7 @@ assignment
  ;
 
 expr
- : or_expr
- ;
-
-or_expr
- : and_expr (Or^ and_expr)*
- ;
-
-and_expr
- : contains_expr (And^ contains_expr)*
+ : contains_expr ((And | Or)^ expr)?
  ;
 
 contains_expr

--- a/src/test/java/liqp/tags/IfTest.java
+++ b/src/test/java/liqp/tags/IfTest.java
@@ -385,4 +385,26 @@ public class IfTest {
 
         // TODO
     }
+
+    /*
+     * In tags with more than one and or or operator, operators are checked in order from right to left.
+     *
+     * {% if true or false and false %}
+     *   This evaluates to true, since the 'and' condition is checked first.
+     * {% endif %}
+     *
+     * {% if true and false and false or true %}
+     *   This evaluates to false, since the tags are checked like this:
+     *
+     *   true and (false and (false or true))
+     *   true and (false and true)
+     *   true and false
+     *   false
+     * {% endif %}
+     */
+    @Test
+    public void and_or_evaluation_orderTest() throws RecognitionException {
+        assertThat(Template.parse("{% if true or false and false %}TRUE{% else %}FALSE{% endif %}").render(), is("TRUE"));
+        assertThat(Template.parse("{% if true and false and false or true %}TRUE{% else %}FALSE{% endif %}").render(), is("FALSE"));
+    }
 }


### PR DESCRIPTION
According to specs: https://help.shopify.com/themes/liquid/basics/operators
In tags with more than one `and` or `or` operator, operators are checked in order from right to left.

I fixed the grammar so it works like that now, also added tests.