### PR TITLE
Use short-circuit evaluation at And and Or operators.

### DIFF
--- a/src/main/java/liqp/nodes/AndNode.java
+++ b/src/main/java/liqp/nodes/AndNode.java
@@ -18,10 +18,7 @@ class AndNode extends LValue implements LNode {
     @Override
     public Object render(TemplateContext context) {
 
-        Object a = lhs.render(context);
-        Object b = rhs.render(context);
-
-        return super.asBoolean(a) && super.asBoolean(b);
+        return super.asBoolean(lhs.render(context)) && super.asBoolean(rhs.render(context));
 
     }
 }

--- a/src/main/java/liqp/nodes/OrNode.java
+++ b/src/main/java/liqp/nodes/OrNode.java
@@ -16,10 +16,7 @@ class OrNode extends LValue implements LNode {
     @Override
     public Object render(TemplateContext context) {
 
-        Object a = lhs.render(context);
-        Object b = rhs.render(context);
-
-        return super.asBoolean(a) || super.asBoolean(b);
+        return super.asBoolean(lhs.render(context)) || super.asBoolean(rhs.render(context));
 
     }
 }

--- a/src/test/java/liqp/RenderSettingsTest.java
+++ b/src/test/java/liqp/RenderSettingsTest.java
@@ -31,4 +31,66 @@ public class RenderSettingsTest {
             assertThat(e.getVariableName(), is("qwe.asd.zxc"));
         }
     }
+
+    @Test
+    public void renderWithStrictVariablesInCondition1() {
+        Template.parse("{% if mu == \"somethingElse\" %}{{ badVariableName }}{% endif %}")
+                .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+                .render("mu", "muValue");
+    }
+
+    @Test
+    public void renderWithStrictVariablesInCondition2() {
+        try {
+            Template.parse("{% if mu == \"muValue\" %}{{ badVariableName }}{% endif %}")
+                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+                    .render("mu", "muValue");
+        } catch (RuntimeException ex) {
+            VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
+            assertThat(e.getVariableName(), is("badVariableName"));
+        }
+    }
+
+    @Test
+    public void renderWithStrictVariablesInAnd1() {
+        try {
+            Template.parse("{% if mu == \"muValue\" and checkThis %}{{ badVariableName }}{% endif %}")
+                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+                    .render("mu", "muValue");
+        } catch (RuntimeException ex) {
+            VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
+            assertThat(e.getVariableName(), is("checkThis"));
+        }
+    }
+
+    @Test
+    public void renderWithStrictVariablesInAnd2() {
+        Template.parse("{% if mu == \"somethingElse\" and doNotCheckThis %}{{ badVariableName }}{% endif %}")
+                .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+                .render("mu", "muValue");
+    }
+
+    @Test
+    public void renderWithStrictVariablesInOr1() {
+        try {
+            Template.parse("{% if mu == \"muValue\" or doNotCheckThis %}{{ badVariableName }}{% endif %}")
+                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+                    .render("mu", "muValue");
+        } catch (RuntimeException ex) {
+            VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
+            assertThat(e.getVariableName(), is("badVariableName"));
+        }
+    }
+
+    @Test
+    public void renderWithStrictVariablesInOr2() {
+        try {
+            Template.parse("{% if mu == \"somethingElse\" or checkThis %}{{ badVariableName }}{% endif %}")
+                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+                    .render("mu", "muValue");
+        } catch (RuntimeException ex) {
+            VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
+            assertThat(e.getVariableName(), is("checkThis"));
+        }
+    }
 }


### PR DESCRIPTION
The reason of this PR that if we are in strict variables mode, then it is not good to check both sides of an And or Or expression.

Small example:
`{% if context.isSpecial and context.special.value == "something" %}`

It would not work because the right side is evaluated as well and the strict value check would throw an exception.

Current workaround is a nested if:
`{% if context.isSpecial %}{% if context.special.value == "something" %}`

That version is too verbose in my opinion.

It does not change the behavior if the strict variable check is turned off.
@bkiers what do you think?