### PR TITLE
Demo of single line break stripping

### DIFF
--- a/src/main/java/liqp/ParseSettings.java
+++ b/src/main/java/liqp/ParseSettings.java
@@ -33,6 +33,11 @@ public class ParseSettings {
         }
 
         public Builder withStripSpaceAroundTags(boolean stripSpacesAroundTags, boolean stripSingleLine) {
+
+            if (stripSingleLine && !stripSpacesAroundTags) {
+                throw new IllegalStateException("stripSpacesAroundTags must be true if stripSingleLine is true");
+            }
+
             this.stripSpacesAroundTags = stripSpacesAroundTags;
             this.stripSingleLine = stripSingleLine;
             return this;

--- a/src/main/java/liqp/ParseSettings.java
+++ b/src/main/java/liqp/ParseSettings.java
@@ -7,12 +7,14 @@ public class ParseSettings {
 
     public final Flavor flavor;
     public final boolean stripSpacesAroundTags;
+    public final boolean stripSingleLine;
     public final ObjectMapper mapper;
 
     public static class Builder {
 
         Flavor flavor;
         boolean stripSpacesAroundTags;
+        boolean stripSingleLine;
         ObjectMapper mapper;
 
         public Builder() {
@@ -27,7 +29,12 @@ public class ParseSettings {
         }
 
         public Builder withStripSpaceAroundTags(boolean stripSpacesAroundTags) {
+            return this.withStripSpaceAroundTags(stripSpacesAroundTags, false);
+        }
+
+        public Builder withStripSpaceAroundTags(boolean stripSpacesAroundTags, boolean stripSingleLine) {
             this.stripSpacesAroundTags = stripSpacesAroundTags;
+            this.stripSingleLine = stripSingleLine;
             return this;
         }
 
@@ -37,13 +44,14 @@ public class ParseSettings {
         }
 
         public ParseSettings build() {
-            return new ParseSettings(this.flavor, this.stripSpacesAroundTags, this.mapper);
+            return new ParseSettings(this.flavor, this.stripSpacesAroundTags, this.stripSingleLine, this.mapper);
         }
     }
 
-    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags, ObjectMapper mapper) {
+    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags, boolean stripSingleLine, ObjectMapper mapper) {
         this.flavor = flavor;
         this.stripSpacesAroundTags = stripSpacesAroundTags;
+        this.stripSingleLine = stripSingleLine;
         this.mapper = mapper;
     }
 }

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -70,7 +70,8 @@ public class Template {
 
         ANTLRStringStream stream = new ANTLRStringStream(input);
         this.templateSize = stream.size();
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(input), parseSettings.stripSpacesAroundTags);
+        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(input),
+                parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
         LiquidParser parser = createParser(lexer);
 
         try {
@@ -96,7 +97,8 @@ public class Template {
         try {
             ANTLRFileStream stream = new ANTLRFileStream(file.getAbsolutePath());
             this.templateSize = stream.size();
-            LiquidLexer lexer = new LiquidLexer(CharStreams.fromFileName(file.getAbsolutePath()), parseSettings.stripSpacesAroundTags);
+            LiquidLexer lexer = new LiquidLexer(CharStreams.fromFileName(file.getAbsolutePath()),
+                    parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
             LiquidParser parser = createParser(lexer);
             root = parser.parse();
         }


### PR DESCRIPTION
Demo for stripping single lines containing tags (instead of many successive empty lines).

```java
String source = "#include <micro-os-plus/board.h>\n" +
        "{% if trace != 'none' %}\n" +
        "#include <micro-os-plus/diag/trace.h>\n" +
        "{% endif %}\n" +
        "\n" +
        "#include <sysclock.h>\n" +
        "{% if content == 'blinky' %}\n" +
        "#include <led.h>\n" +
        "{% endif %}\n" +
        "\n" +
        "#include <stdint.h>\n" +
        "#include <stdio.h>\n" +
        "\n" +
        "// ----------------------------------------------------------------------------\n" +
        "\n" +
        "{% if language == 'cpp' %}\n" +
        "using namespace os;\n" +
        "\n" +
        "{% endif %}\n";

ParseSettings settings = new ParseSettings.Builder()
        .withStripSpaceAroundTags(true, true)
        .build();

String rendered = Template.parse(source, settings).render();
System.out.printf(">>>\n%s<<<", rendered);

/*
>>>
#include <micro-os-plus/board.h>
#include <micro-os-plus/diag/trace.h>

#include <sysclock.h>

#include <stdint.h>
#include <stdio.h>

// ----------------------------------------------------------------------------

<<<
*/
```