### PR TITLE
Clone `variables` map when building the TemplateContext

### DIFF
--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -26,7 +26,7 @@ public class TemplateContext {
         this.protectionSettings = protectionSettings;
         this.renderSettings = renderSettings;
         this.flavor = flavor;
-        this.variables = variables;
+        this.variables = new LinkedHashMap<String, Object>(variables);
     }
 
     public TemplateContext(TemplateContext parent) {


### PR DESCRIPTION
Iterating over an array with a `for` loop mutates the variables map adding a `continue` key: https://github.com/bkiers/Liqp/blob/master/src/main/java/liqp/tags/For.java#L145

This is not only a leaky abstraction, but it also presents problems when using this library with JVM languages that favor immutability (e.g. Scala).

This PR addresses this problem by forcing the `TemplateContext` to always make an internal copy of the `variables` object to a `LinkedHashMap`.