### PR TITLE
Remove dependency on ANTLR3 and antlr4-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,20 +74,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr-runtime</artifactId>
-      <version>${antlr.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr-runtime</artifactId>
-      <version>${antlr.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,18 +64,6 @@
     <snapshotUrl>${repoHost}/content/repositories/snapshots</snapshotUrl>
   </properties>
 
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <id>spring</id>
-      <name>Spring Lib Release</name>
-      <url>http://repo.spring.io/libs-release/</url>
-      <layout>default</layout>
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <dependency>
@@ -97,12 +85,6 @@
       <artifactId>antlr-runtime</artifactId>
       <version>${antlr.version}</version>
       <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>edu.emory.mathcs.backport</groupId>
-      <artifactId>com.springsource.edu.emory.mathcs.backport</artifactId>
-      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,18 @@
     <snapshotUrl>${repoHost}/content/repositories/snapshots</snapshotUrl>
   </properties>
 
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <id>spring</id>
+      <name>Spring Lib Release</name>
+      <url>http://repo.spring.io/libs-release/</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
   <dependencies>
 
     <dependency>
@@ -75,9 +87,22 @@
 
     <dependency>
       <groupId>org.antlr</groupId>
-      <artifactId>antlr4-maven-plugin</artifactId>
-      <version>${antlr4.version}</version>
+      <artifactId>antlr-runtime</artifactId>
+      <version>${antlr.version}</version>
       <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr-runtime</artifactId>
+      <version>${antlr.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>edu.emory.mathcs.backport</groupId>
+      <artifactId>com.springsource.edu.emory.mathcs.backport</artifactId>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -8,9 +8,6 @@ import liqp.parser.v4.NodeVisitor;
 import liqp.tags.Tag;
 import liquid.parser.v4.LiquidLexer;
 import liquid.parser.v4.LiquidParser;
-import org.antlr.runtime.ANTLRFileStream;
-import org.antlr.runtime.ANTLRStringStream;
-import org.antlr.runtime.tree.CommonTree;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -69,10 +66,9 @@ public class Template {
         this.filters = filters;
         this.parseSettings = parseSettings;
 
-        ANTLRStringStream stream = new ANTLRStringStream(input);
+        CharStream stream = CharStreams.fromString(input);
         this.templateSize = stream.size();
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(input),
-                parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
+        LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
         try {
              root = parse(lexer);
         }
@@ -92,12 +88,11 @@ public class Template {
         this.tags = tags;
         this.filters = filters;
         this.parseSettings = parseSettings;
+        CharStream stream = CharStreams.fromFileName(file.getAbsolutePath());
 
         try {
-            ANTLRFileStream stream = new ANTLRFileStream(file.getAbsolutePath());
             this.templateSize = stream.size();
-            LiquidLexer lexer = new LiquidLexer(CharStreams.fromFileName(file.getAbsolutePath()),
-                    parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
+            LiquidLexer lexer = new LiquidLexer(stream, parseSettings.stripSpacesAroundTags, parseSettings.stripSingleLine);
             root = parse(lexer);
         }
         catch (Exception e) {
@@ -137,12 +132,6 @@ public class Template {
             parser.getInterpreter().setPredictionMode(PredictionMode.LL);
             return parser.parse();
         }
-    }
-
-    // Use getParseTree()
-    @Deprecated
-    public CommonTree getAST() {
-        throw new UnsupportedOperationException("The ANTLR3 CommonTree isn't available in this version of Liqp, use: getParseTree()");
     }
 
     /**

--- a/src/main/java/liqp/filters/Concat.java
+++ b/src/main/java/liqp/filters/Concat.java
@@ -1,7 +1,6 @@
 package liqp.filters;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
-
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/liqp/filters/Reverse.java
+++ b/src/main/java/liqp/filters/Reverse.java
@@ -1,9 +1,8 @@
 package liqp.filters;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class Reverse extends Filter {

--- a/src/main/java/liqp/filters/Sort_Natural.java
+++ b/src/main/java/liqp/filters/Sort_Natural.java
@@ -1,7 +1,5 @@
 package liqp.filters;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-
 import java.util.*;
 
 public class Sort_Natural extends Filter {

--- a/src/main/java/liqp/nodes/FilterNode.java
+++ b/src/main/java/liqp/nodes/FilterNode.java
@@ -1,13 +1,8 @@
 package liqp.nodes;
 
 import liqp.TemplateContext;
-import liqp.exceptions.LiquidException;
 import liqp.filters.Filter;
-import org.antlr.runtime.tree.CommonTree;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/liqp/TemplateTest.java
+++ b/src/test/java/liqp/TemplateTest.java
@@ -1,6 +1,6 @@
 package liqp;
 
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/AbsTest.java
+++ b/src/test/java/liqp/filters/AbsTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/AppendTest.java
+++ b/src/test/java/liqp/filters/AppendTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/At_LeastTest.java
+++ b/src/test/java/liqp/filters/At_LeastTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/At_MostTest.java
+++ b/src/test/java/liqp/filters/At_MostTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/CapitalizeTest.java
+++ b/src/test/java/liqp/filters/CapitalizeTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/CeilTest.java
+++ b/src/test/java/liqp/filters/CeilTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/CompactTest.java
+++ b/src/test/java/liqp/filters/CompactTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/DateTest.java
+++ b/src/test/java/liqp/filters/DateTest.java
@@ -2,7 +2,7 @@ package liqp.filters;
 
 import java.util.Locale;
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;

--- a/src/test/java/liqp/filters/DefaultTest.java
+++ b/src/test/java/liqp/filters/DefaultTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Divided_ByTest.java
+++ b/src/test/java/liqp/filters/Divided_ByTest.java
@@ -1,11 +1,8 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/liqp/filters/DowncaseTest.java
+++ b/src/test/java/liqp/filters/DowncaseTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/EscapeTest.java
+++ b/src/test/java/liqp/filters/EscapeTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Escape_OnceTest.java
+++ b/src/test/java/liqp/filters/Escape_OnceTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/FilterTest.java
+++ b/src/test/java/liqp/filters/FilterTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/FirstTest.java
+++ b/src/test/java/liqp/filters/FirstTest.java
@@ -1,11 +1,8 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/liqp/filters/FloorTest.java
+++ b/src/test/java/liqp/filters/FloorTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/HTest.java
+++ b/src/test/java/liqp/filters/HTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/JoinTest.java
+++ b/src/test/java/liqp/filters/JoinTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/LastTest.java
+++ b/src/test/java/liqp/filters/LastTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/LstripTest.java
+++ b/src/test/java/liqp/filters/LstripTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/MapTest.java
+++ b/src/test/java/liqp/filters/MapTest.java
@@ -2,7 +2,7 @@ package liqp.filters;
 
 import java.util.HashMap;
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/MinusTest.java
+++ b/src/test/java/liqp/filters/MinusTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/ModuloTest.java
+++ b/src/test/java/liqp/filters/ModuloTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Newline_To_BrTest.java
+++ b/src/test/java/liqp/filters/Newline_To_BrTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/PlusTest.java
+++ b/src/test/java/liqp/filters/PlusTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/PrependTest.java
+++ b/src/test/java/liqp/filters/PrependTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/RemoveTest.java
+++ b/src/test/java/liqp/filters/RemoveTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Remove_FirstTest.java
+++ b/src/test/java/liqp/filters/Remove_FirstTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/ReplaceTest.java
+++ b/src/test/java/liqp/filters/ReplaceTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Replace_FirstTest.java
+++ b/src/test/java/liqp/filters/Replace_FirstTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/ReverseTest.java
+++ b/src/test/java/liqp/filters/ReverseTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/RoundTest.java
+++ b/src/test/java/liqp/filters/RoundTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/RstripTest.java
+++ b/src/test/java/liqp/filters/RstripTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/SizeTest.java
+++ b/src/test/java/liqp/filters/SizeTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/SortTest.java
+++ b/src/test/java/liqp/filters/SortTest.java
@@ -1,10 +1,10 @@
 package liqp.filters;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
+
+import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/liqp/filters/Sort_NaturalTest.java
+++ b/src/test/java/liqp/filters/Sort_NaturalTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/SplitTest.java
+++ b/src/test/java/liqp/filters/SplitTest.java
@@ -2,7 +2,7 @@ package liqp.filters;
 
 import java.util.regex.Pattern;
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/StripTest.java
+++ b/src/test/java/liqp/filters/StripTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Strip_HTMLTest.java
+++ b/src/test/java/liqp/filters/Strip_HTMLTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Strip_NewlinesTest.java
+++ b/src/test/java/liqp/filters/Strip_NewlinesTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/TimesTest.java
+++ b/src/test/java/liqp/filters/TimesTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/TruncateTest.java
+++ b/src/test/java/liqp/filters/TruncateTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/TruncatewordsTest.java
+++ b/src/test/java/liqp/filters/TruncatewordsTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/UniqTest.java
+++ b/src/test/java/liqp/filters/UniqTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/UpcaseTest.java
+++ b/src/test/java/liqp/filters/UpcaseTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Url_DecodeTest.java
+++ b/src/test/java/liqp/filters/Url_DecodeTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/filters/Url_EncodeTest.java
+++ b/src/test/java/liqp/filters/Url_EncodeTest.java
@@ -1,7 +1,7 @@
 package liqp.filters;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/AndNodeTest.java
+++ b/src/test/java/liqp/nodes/AndNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/AtomNodeTest.java
+++ b/src/test/java/liqp/nodes/AtomNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/BlockNodeTest.java
+++ b/src/test/java/liqp/nodes/BlockNodeTest.java
@@ -3,7 +3,7 @@ package liqp.nodes;
 import liqp.Template;
 import liqp.TemplateContext;
 import liqp.tags.Tag;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 public class BlockNodeTest {

--- a/src/test/java/liqp/nodes/EqNodeTest.java
+++ b/src/test/java/liqp/nodes/EqNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/GtEqNodeTest.java
+++ b/src/test/java/liqp/nodes/GtEqNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/GtNodeTest.java
+++ b/src/test/java/liqp/nodes/GtNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/LookupNodeTest.java
+++ b/src/test/java/liqp/nodes/LookupNodeTest.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import liqp.Template;
 import liqp.TemplateContext;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static liqp.TestUtils.getNode;

--- a/src/test/java/liqp/nodes/LtEqNodeTest.java
+++ b/src/test/java/liqp/nodes/LtEqNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/LtNodeTest.java
+++ b/src/test/java/liqp/nodes/LtNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/NEqNodeTest.java
+++ b/src/test/java/liqp/nodes/NEqNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/OrNodeTest.java
+++ b/src/test/java/liqp/nodes/OrNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/nodes/OutputNodeTest.java
+++ b/src/test/java/liqp/nodes/OutputNodeTest.java
@@ -1,7 +1,7 @@
 package liqp.nodes;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/AssignTest.java
+++ b/src/test/java/liqp/tags/AssignTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/CaptureTest.java
+++ b/src/test/java/liqp/tags/CaptureTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/CaseTest.java
+++ b/src/test/java/liqp/tags/CaseTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/CommentTest.java
+++ b/src/test/java/liqp/tags/CommentTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/CycleTest.java
+++ b/src/test/java/liqp/tags/CycleTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/DecrementTest.java
+++ b/src/test/java/liqp/tags/DecrementTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/ForTest.java
+++ b/src/test/java/liqp/tags/ForTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import java.util.HashMap;

--- a/src/test/java/liqp/tags/IfTest.java
+++ b/src/test/java/liqp/tags/IfTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -2,7 +2,7 @@ package liqp.tags;
 
 import liqp.*;
 import liqp.parser.Flavor;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import java.io.File;

--- a/src/test/java/liqp/tags/IncrementTest.java
+++ b/src/test/java/liqp/tags/IncrementTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/RawTest.java
+++ b/src/test/java/liqp/tags/RawTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/TablerowTest.java
+++ b/src/test/java/liqp/tags/TablerowTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/TagTest.java
+++ b/src/test/java/liqp/tags/TagTest.java
@@ -3,13 +3,10 @@ package liqp.tags;
 import liqp.Template;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class TagTest {

--- a/src/test/java/liqp/tags/UnlessTest.java
+++ b/src/test/java/liqp/tags/UnlessTest.java
@@ -1,7 +1,7 @@
 package liqp.tags;
 
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/WhitespaceControlTest.java
+++ b/src/test/java/liqp/tags/WhitespaceControlTest.java
@@ -2,7 +2,7 @@ package liqp.tags;
 
 import liqp.ParseSettings;
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/tags/WhitespaceWindowsControlTest.java
+++ b/src/test/java/liqp/tags/WhitespaceWindowsControlTest.java
@@ -2,7 +2,7 @@ package liqp.tags;
 
 import liqp.ParseSettings;
 import liqp.Template;
-import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;


### PR DESCRIPTION
AFAIK, the `antlr4-maven-plugin` dependency is only needed at compile time.

It was being included and available at runtime, bringing with it a lot of dependencies (see #98)

This PR removes the dependency on that library at runtime and the dependencies on `edu.emory.mathcs.backport` and ANTLR3 (both those libraries were available thanks to the plugin).

I think that everything is working as expected, but ANTLR4 uses different Exceptions. When reviewing this PR, please check if the new `LiquidException` messages make sense.