### PR TITLE
Adds Template.renderUnguarded for faster rendering.

### DIFF
--- a/src/main/java/liqp/ProtectionSettings.java
+++ b/src/main/java/liqp/ProtectionSettings.java
@@ -66,4 +66,8 @@ public class ProtectionSettings {
             throw new ExceededMaxIterationsException(this.maxIterations);
         }
     }
+
+    public Boolean isRenderTimeLimited() {
+        return this.maxRenderTimeMillis != Long.MAX_VALUE;
+    }
 }

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -282,7 +282,15 @@ public class Template {
      * @return a string denoting the rendered template.
      */
     public String render(final Map<String, Object> variables) {
-        return render(variables, Executors.newSingleThreadExecutor(), true);
+
+        if (this.protectionSettings.isRenderTimeLimited()) {
+            return render(variables, Executors.newSingleThreadExecutor(), true);
+        } else {
+            if (this.templateSize > this.protectionSettings.maxTemplateSizeBytes) {
+                throw new RuntimeException("template exceeds " + this.protectionSettings.maxTemplateSizeBytes + " bytes");
+            }
+            return renderUnguarded(variables);
+        }
     }
 
     public String render(final Map<String, Object> variables, ExecutorService executorService, boolean shutdown) {

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -291,18 +291,9 @@ public class Template {
             throw new RuntimeException("template exceeds " + this.protectionSettings.maxTemplateSizeBytes + " bytes");
         }
 
-        final NodeVisitor visitor = new NodeVisitor(this.tags, this.filters, this.parseSettings);
-
         Callable<String> task = new Callable<String>() {
-            public String call() throws Exception {
-                try {
-                    LNode node = visitor.visit(root);
-                    Object rendered = node.render(new TemplateContext(protectionSettings, renderSettings, parseSettings.flavor, variables));
-                    return rendered == null ? "" : String.valueOf(rendered);
-                }
-                catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+            public String call() {
+                return renderUnguarded(variables);
             }
         };
 
@@ -321,6 +312,29 @@ public class Template {
             if (shutdown) {
                 executorService.shutdown();
             }
+        }
+    }
+
+    /**
+     * Renders the template without guards provided by protection settings. This method has about 300x times
+     * better performance than plain render.
+     *
+     * @param variables
+     *         a Map denoting the (possibly nested)
+     *         variables that can be used in this
+     *         Template.
+     *
+     * @return a string denoting the rendered template.
+     */
+    public String renderUnguarded(final Map<String, Object> variables) {
+        final NodeVisitor visitor = new NodeVisitor(this.tags, this.filters, this.parseSettings);
+        try {
+            LNode node = visitor.visit(root);
+            Object rendered = node.render(new TemplateContext(protectionSettings, renderSettings, parseSettings.flavor, variables));
+            return rendered == null ? "" : String.valueOf(rendered);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Current default Template.render() method creates new executor for
each call, which is amazingly slow. As changing this isn't easy without
API breakage, this commit introduces new method for those cases where
rendering speed is more important than guards provided by
protection settings.

To highlight the performance difference, below is benchmark of just rendering {{field}} template with render and renderUnguarded

```
Benchmark                                               Mode  Cnt        Score        Error  Units
LiquidTemplateBenchmark.renderSimpleVariable           thrpt    5    15561.248 ±   1479.127  ops/s
LiquidTemplateBenchmark.renderSimpleVariableUnguarded  thrpt    5  6108577.637 ± 675207.396  ops/s
```

I would also suggest changing documentation + JavaDoc so that it highlights performance impact of calling plain render without ExecutionService. Didn't however add it to PR yet without discussion.