### PR TITLE
Move lexer predicates to the right hand side

### DIFF
--- a/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
@@ -16,16 +16,16 @@ lexer grammar LiquidLexer;
 }
 
 OutStart
- : ( {stripSpacesAroundTags && stripSingleLine}? SpaceOrTab* '{{'
-   | {stripSpacesAroundTags && !stripSingleLine}? WhitespaceChar* '{{'
+ : ( SpaceOrTab* '{{' {stripSpacesAroundTags && stripSingleLine}?
+   | WhitespaceChar* '{{' {stripSpacesAroundTags && !stripSingleLine}?
    | WhitespaceChar* '{{-'
    | '{{'
    ) -> pushMode(IN_TAG)
  ;
 
 TagStart
- : ( {stripSpacesAroundTags && stripSingleLine}? SpaceOrTab* '{%'
-   | {stripSpacesAroundTags && !stripSingleLine}? WhitespaceChar* '{%'
+ : ( SpaceOrTab* '{%' {stripSpacesAroundTags && stripSingleLine}?
+   | WhitespaceChar* '{%' {stripSpacesAroundTags && !stripSingleLine}?
    | WhitespaceChar* '{%-'
    | '{%'
    ) -> pushMode(IN_TAG)
@@ -49,16 +49,16 @@ mode IN_TAG;
   TagStart2 : '{%' -> pushMode(IN_TAG);
 
   OutEnd
-   : ( {stripSpacesAroundTags && stripSingleLine}? '}}' SpaceOrTab* LineBreak?
-     | {stripSpacesAroundTags && !stripSingleLine}? '}}' WhitespaceChar*
+   : ( '}}' SpaceOrTab* LineBreak? {stripSpacesAroundTags && stripSingleLine}?
+     | '}}' WhitespaceChar* {stripSpacesAroundTags && !stripSingleLine}?
      | '-}}' WhitespaceChar*
      | '}}'
      ) -> popMode
    ;
 
   TagEnd
-   : ( {stripSpacesAroundTags && stripSingleLine}? '%}' SpaceOrTab* LineBreak?
-     | {stripSpacesAroundTags && !stripSingleLine}? '%}' WhitespaceChar*
+   : ( '%}' SpaceOrTab* LineBreak? {stripSpacesAroundTags && stripSingleLine}?
+     | '%}' WhitespaceChar* {stripSpacesAroundTags && !stripSingleLine}?
      | '-%}' WhitespaceChar*
      | '%}'
      ) -> popMode


### PR DESCRIPTION
Moves the lexer predicates to the right side of the rule, as suggested by:  https://github.com/antlr/antlr4/blob/master/doc/predicates.md#predicates-in-lexer-rules

Addresses #93 (not sure if this can be considered fixed yet).

Using @mbaumbach [benchmarks](https://gist.github.com/mbaumbach/e6e5114bb9220fdd37088608dab9e463):

**Old Version**
```
Parsing small
Parse time (attempt: 1): 352
Parse time (attempt: 2): 2
Parse time (attempt: 3): 2
Parse time (attempt: 4): 2
Parse time (attempt: 5): 1
Parse time (attempt: 6): 2
Parse time (attempt: 7): 1
Parse time (attempt: 8): 2
Parse time (attempt: 9): 2
Parse time (attempt: 10): 1
Parsing medium
Parse time (attempt: 1): 99
Parse time (attempt: 2): 96
Parse time (attempt: 3): 73
Parse time (attempt: 4): 55
Parse time (attempt: 5): 77
Parse time (attempt: 6): 58
Parse time (attempt: 7): 54
Parse time (attempt: 8): 46
Parse time (attempt: 9): 35
Parse time (attempt: 10): 45
Parsing large
Parse time (attempt: 1): 120
Parse time (attempt: 2): 83
Parse time (attempt: 3): 127
Parse time (attempt: 4): 100
Parse time (attempt: 5): 86
Parse time (attempt: 6): 93
Parse time (attempt: 7): 128
Parse time (attempt: 8): 164
Parse time (attempt: 9): 78
Parse time (attempt: 10): 74
```

**New Version**
```
Parsing small
Parse time (attempt: 1): 311
Parse time (attempt: 2): 2
Parse time (attempt: 3): 1
Parse time (attempt: 4): 2
Parse time (attempt: 5): 0
Parse time (attempt: 6): 0
Parse time (attempt: 7): 0
Parse time (attempt: 8): 1
Parse time (attempt: 9): 0
Parse time (attempt: 10): 0
Parsing medium
Parse time (attempt: 1): 27
Parse time (attempt: 2): 14
Parse time (attempt: 3): 12
Parse time (attempt: 4): 10
Parse time (attempt: 5): 9
Parse time (attempt: 6): 8
Parse time (attempt: 7): 7
Parse time (attempt: 8): 7
Parse time (attempt: 9): 7
Parse time (attempt: 10): 7
Parsing large
Parse time (attempt: 1): 31
Parse time (attempt: 2): 35
Parse time (attempt: 3): 38
Parse time (attempt: 4): 32
Parse time (attempt: 5): 24
Parse time (attempt: 6): 26
Parse time (attempt: 7): 30
Parse time (attempt: 8): 30
Parse time (attempt: 9): 16
Parse time (attempt: 10): 21
```