### PR TITLE
Use HALF_UP RoundingMode to match Liquid spec

### DIFF
--- a/src/main/java/liqp/filters/Round.java
+++ b/src/main/java/liqp/filters/Round.java
@@ -1,5 +1,6 @@
 package liqp.filters;
 
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 
 public class Round extends Filter {
@@ -28,6 +29,7 @@ public class Round extends Filter {
         }
 
         DecimalFormat formatter = new DecimalFormat(formatBuilder.toString());
+        formatter.setRoundingMode(RoundingMode.HALF_UP);
 
         return formatter.format(number);
     }

--- a/src/test/java/liqp/filters/RoundTest.java
+++ b/src/test/java/liqp/filters/RoundTest.java
@@ -26,6 +26,7 @@ public class RoundTest {
                 {"{{ 'MU' | round }}", "0", "{}"},
                 {"{{ input | round }}", "5", "{ \"input\": 4.6 }"},
                 {"{{ '4.3' | round }}", "4", "{}"},
+                {"{{ '10.5' | round }}", "11", "{}"},
                 {"{{ input | round: 2 }}", "4.56", "{ \"input\": 4.5612 }"},
                 {"{{ input | round: 2.999 }}", "4.56", "{ \"input\": 4.5612 }"},
                 {"{{ price | round }}", "5", "{ \"price\": 4.6 }"},


### PR DESCRIPTION
Fix for issue #106. Defaults to using the HALF_UP RoundingMode to match Liquid's [spec for round](https://shopify.github.io/liquid/filters/round/):

> Rounds an input number to the **nearest integer** or, if a number is specified as an argument, to that number of decimal places.