### PR TITLE
Upped Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <antlr.version>3.5.1</antlr.version>
     <antlr4.version>4.7.1</antlr4.version>
-    <jackson.version>2.9.6</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <jsoup.version>1.10.3</jsoup.version>
     <junit.version>4.12</junit.version>
 


### PR DESCRIPTION
Security fix for Jackson 2.9.6

See: https://nvd.nist.gov/vuln/detail/CVE-2018-19360