### PR TITLE
Remove string coercion from first and last filters

### DIFF
--- a/src/main/java/liqp/filters/First.java
+++ b/src/main/java/liqp/filters/First.java
@@ -12,6 +12,6 @@ public class First extends Filter {
 
         Object[] array = super.asArray(value);
 
-        return array.length == 0 ? null : super.asString(array[0]);
+        return array.length == 0 ? null : array[0];
     }
 }

--- a/src/main/java/liqp/filters/Last.java
+++ b/src/main/java/liqp/filters/Last.java
@@ -12,6 +12,6 @@ public class Last extends Filter {
 
         Object[] array = super.asArray(value);
 
-        return array.length == 0 ? null : super.asString(array[array.length - 1]);
+        return array.length == 0 ? null : array[array.length - 1];
     }
 }

--- a/src/test/java/liqp/filters/FirstTest.java
+++ b/src/test/java/liqp/filters/FirstTest.java
@@ -18,6 +18,15 @@ public class FirstTest {
 
         assertThat(rendered, is("Mu"));
     }
+    
+    @Test
+    public void applyObjectTest() {
+    	Template template = Template.parse("{%- assign product = values | first -%}{{product.title}} {{product.price}}");
+
+        String rendered = String.valueOf(template.render("{\"values\" : [{ \"title\": \"Product 1\", \"price\": 1299 }, { \"title\": \"Product 2\", \"price\": 2999 }]}"));
+
+        assertThat(rendered, is("Product 1 1299"));
+    }
 
     /*
      * def test_first_last
@@ -32,7 +41,7 @@ public class FirstTest {
 
         Filter filter = Filter.getFilter("first");
 
-        assertThat(filter.apply(new Integer[]{1, 2, 3}), is((Object)"1"));
+        assertThat(filter.apply(new Integer[]{1, 2, 3}), is((Object)1));
         assertThat(filter.apply(new Integer[]{}), is((Object)null));
     }
 }

--- a/src/test/java/liqp/filters/LastTest.java
+++ b/src/test/java/liqp/filters/LastTest.java
@@ -18,6 +18,15 @@ public class LastTest {
 
         assertThat(rendered, is("bar"));
     }
+    
+    @Test
+    public void applyObjectTest() {
+    	Template template = Template.parse("{%- assign product = values | last -%}{{product.title}} {{product.price}}");
+
+        String rendered = String.valueOf(template.render("{\"values\" : [{ \"title\": \"Product 1\", \"price\": 1299 }, { \"title\": \"Product 2\", \"price\": 2999 }]}"));
+
+        assertThat(rendered, is("Product 2 2999"));
+    }
 
     /*
      * def test_first_last
@@ -32,7 +41,7 @@ public class LastTest {
 
         Filter filter = Filter.getFilter("last");
 
-        assertThat(filter.apply(new Integer[]{1, 2, 3}), is((Object)"3"));
+        assertThat(filter.apply(new Integer[]{1, 2, 3}), is((Object)3));
         assertThat(filter.apply(new Integer[]{}), is((Object)null));
     }
 }


### PR DESCRIPTION
This should resolve #119. I added a test for each filter to verify getting data out of an object after using the filters.