### PR TITLE
Added support of "blank" literal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <exclude>**/TestUtils.java</exclude>

--- a/ruby/_helpers.rb
+++ b/ruby/_helpers.rb
@@ -1,0 +1,33 @@
+begin
+  require "jekyll"
+  puts "testing cases using jekyll"
+rescue LoadError
+  require "liquid"
+  puts "testing cases using liquid"
+end
+
+Liquid::Template.error_mode = :strict
+
+def assertEqual(expected, real)
+  if expected != real
+    raise
+  end
+end
+
+def assertRaise(&block)
+  begin
+    block.call
+  rescue
+    return
+  end
+  raise 'expected exception'
+end
+
+
+def parse(source, options = {})
+  Liquid::Template.parse(source, options)
+end
+
+def render(source, data = {}, options = {:strict_variables => true})
+  parse(source).render!(data, options);
+end

--- a/ruby/docker_images/jekyll/Dockerfile
+++ b/ruby/docker_images/jekyll/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:latest
+
+RUN mkdir -p /usr/local/etc \
+  && { \
+    echo 'install: --no-document'; \
+    echo 'update: --no-document'; \
+  } >> /etc/gemrc
+
+RUN apk update && apk add --no-cache \
+  ruby \
+  ruby-irb \
+  ruby-json \
+  ruby-bundler \
+  ruby-bigdecimal \
+	ruby-dev \
+	build-base \
+  libssl1.1 \
+  libc6-compat
+
+RUN gem install jekyll
+
+RUN mkdir -p /srv/jekyll
+WORKDIR /srv/jekyll
+VOLUME  /srv/jekyll
+
+ENTRYPOINT ["ruby"]

--- a/ruby/docker_images/liquid/Dockerfile
+++ b/ruby/docker_images/liquid/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:latest
+
+RUN mkdir -p /usr/local/etc \
+  && { \
+    echo 'install: --no-document'; \
+    echo 'update: --no-document'; \
+  } >> /etc/gemrc
+
+RUN apk update && apk add --no-cache \
+  ruby \
+  ruby-irb \
+  ruby-json \
+  ruby-bundler \
+  ruby-bigdecimal \
+	ruby-dev \
+	build-base \
+  libssl1.1 \
+  libc6-compat
+
+RUN gem install liquid
+
+RUN mkdir -p /srv/liquid
+WORKDIR /srv/liquid
+VOLUME  /srv/liquid
+
+ENTRYPOINT ["ruby"]

--- a/ruby/empty_and_blank.rb
+++ b/ruby/empty_and_blank.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require_relative '_helpers.rb'
+
+assertEqual("  true  ", parse(" {% if array == empty %} true {% else %} false {% endif %} ").render!({"array" => []}, :strict_variables => true))
+assertRaise do
+  # because array dont support "blank" message
+  assertEqual("  true  ", parse(" {% if array == blank %} true {% else %} false {% endif %} ").render!({"array" => []}, :strict_variables => true))
+end
+# but it do support the 'nil' message
+assertEqual("  true  ", parse(" {% if array == nil %} false {% else %} true {% endif %} ").render!({"array" => []}, :strict_variables => true))
+
+assertEqual(" empty=><=", render("{% assign a=empty     %} empty=>{{ a }}<="))
+assertEqual(" blank=><=", render("{% assign a=blank     %} blank=>{{ a }}<="))
+
+# equality verification
+assertEqual('', render('{% if true == empty %}?{% endif %}'))
+assertEqual('', render('{% if true == null %}?{% endif %}'))
+assertEqual('', render('{% if true == blank %}?{% endif %}'))
+
+assertEqual('', render('{% if empty == true %}?{% endif %}'))
+assertEqual('', render('{% if empty == null %}?{% endif %}'))
+assertEqual('', render('{% if empty == blank %}?{% endif %}'))
+
+assertEqual('', render('{% if null == true %}?{% endif %}'))
+assertEqual('', render('{% if null == empty %}?{% endif %}'))
+assertEqual('', render('{% if null == blank %}?{% endif %}'))
+
+assertEqual('', render('{% if blank == true %}?{% endif %}'))
+assertEqual('', render('{% if blank == empty %}?{% endif %}'))
+assertEqual('', render('{% if blank == null %}?{% endif %}'))
+
+# conclusion:
+# the 'blank?' not works out of box of liquid till the RoR is not loaded as this message support came from there
+# https://stackoverflow.com/a/888877
+# there is no chance that RoR will be ported to java
+# so our templates will support this as a literal
+# but will not mimic the RoR logic behind that
+
+

--- a/ruby/run_with_jekyll.sh
+++ b/ruby/run_with_jekyll.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if ! docker inspect ruby_with_jekyll > /dev/null 2>&1; then
+  docker build -t ruby_with_jekyll ./docker_images/jekyll
+fi
+
+docker run -it --rm --name jekyll \
+    --volume=$PWD:/srv/jekyll \
+     ruby_with_jekyll \
+     $1

--- a/ruby/run_with_liquid.sh
+++ b/ruby/run_with_liquid.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if ! docker inspect ruby_with_liquid > /dev/null 2>&1; then
+  docker build -t ruby_with_liquid ./docker_images/liquid
+fi
+
+docker run -it --rm --name liquid \
+    --volume=$PWD:/srv/liquid \
+     ruby_with_liquid \
+     $1

--- a/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
@@ -125,6 +125,7 @@ mode IN_TAG;
   Include      : 'include';
   With         : 'with';
   Empty        : 'empty';
+  Blank        : 'blank';
   EndId        : 'end' Id;
 
   Id : ( Letter | '_' ) (Letter | '_' | '-' | Digit)*;

--- a/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
@@ -171,6 +171,7 @@ term
  | Nil            #term_Nil
  | lookup         #term_lookup
  | Empty          #term_Empty
+ | Blank          #term_Blank
  | OPar expr CPar #term_expr
  ;
 
@@ -182,42 +183,42 @@ lookup
 
 id
  : Id
- | CaptureStart  
- | CaptureEnd  
- | CommentStart  
- | CommentEnd  
- | RawStart  
- | RawEnd  
- | IfStart  
- | Elsif  
- | IfEnd  
- | UnlessStart  
- | UnlessEnd  
- | Else  
- | Contains  
- | CaseStart  
- | CaseEnd  
- | When  
- | Cycle  
- | ForStart  
- | ForEnd  
- | In  
- | And  
- | Or  
- | TableStart  
- | TableEnd  
- | Assign  
- | Include  
- | With  
+ | CaptureStart
+ | CaptureEnd
+ | CommentStart
+ | CommentEnd
+ | RawStart
+ | RawEnd
+ | IfStart
+ | Elsif
+ | IfEnd
+ | UnlessStart
+ | UnlessEnd
+ | Else
+ | Contains
+ | CaseStart
+ | CaseEnd
+ | When
+ | Cycle
+ | ForStart
+ | ForEnd
+ | In
+ | And
+ | Or
+ | TableStart
+ | TableEnd
+ | Assign
+ | Include
+ | With
  | EndId
  ;
 
 id2
  : id
- | Empty  
- | Nil  
- | True  
- | False  
+ | Empty
+ | Nil
+ | True
+ | False
  ;
 
 index
@@ -226,7 +227,7 @@ index
  ;
 
 other_tag_parameters
- : other_than_tag_end  
+ : other_than_tag_end
  ;
 
 other_than_tag_end

--- a/src/main/java/liqp/nodes/AtomNode.java
+++ b/src/main/java/liqp/nodes/AtomNode.java
@@ -5,6 +5,7 @@ import liqp.TemplateContext;
 public class AtomNode implements LNode {
 
     public static final AtomNode EMPTY = new AtomNode(new Object());
+    public static final AtomNode BLANK = new AtomNode(new Object());
 
     private Object value;
 
@@ -14,6 +15,10 @@ public class AtomNode implements LNode {
 
     public static boolean isEmpty(Object o) {
         return o == EMPTY.value;
+    }
+
+    public static boolean isBlank(Object o) {
+        return o == BLANK.value;
     }
 
     @Override

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -617,6 +617,16 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
 
   // term
   //  : ...
+  //  | Blank          #term_Blank
+  //  | ...
+  //  ;
+  @Override
+  public LNode visitTerm_Blank(Term_BlankContext ctx) {
+    return AtomNode.BLANK;
+  }
+
+  // term
+  //  : ...
   //  | OPar expr CPar #term_expr
   //  ;
   @Override

--- a/src/test/java/liqp/nodes/EqNodeTest.java
+++ b/src/test/java/liqp/nodes/EqNodeTest.java
@@ -32,8 +32,19 @@ public class EqNodeTest {
      * def test_illegal_symbols
      *   assert_template_result('', '{% if true == empty %}?{% endif %}', {})
      *   assert_template_result('', '{% if true == null %}?{% endif %}', {})
+     *   assert_template_result('', '{% if true == blank %}?{% endif %}', {})
+     *
      *   assert_template_result('', '{% if empty == true %}?{% endif %}', {})
+     *   assert_template_result('', '{% if empty == null %}?{% endif %}', {})
+     *   assert_template_result('', '{% if empty == blank %}?{% endif %}', {})
+     *
      *   assert_template_result('', '{% if null == true %}?{% endif %}', {})
+     *   assert_template_result('', '{% if null == empty %}?{% endif %}', {})
+     *   assert_template_result('', '{% if null == blank %}?{% endif %}', {})
+     *
+     *   assert_template_result('', '{% if blank == true %}?{% endif %}', {})
+     *   assert_template_result('', '{% if blank == empty %}?{% endif %}', {})
+     *   assert_template_result('', '{% if blank == null %}?{% endif %}', {})
      * end
      */
     @Test
@@ -41,7 +52,18 @@ public class EqNodeTest {
 
         assertThat(Template.parse("{% if true == empty %}?{% endif %}").render(), is(""));
         assertThat(Template.parse("{% if true == null %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if true == blank %}?{% endif %}").render(), is(""));
+
         assertThat(Template.parse("{% if empty == true %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if empty == null %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if empty == blank %}?{% endif %}").render(), is(""));
+
         assertThat(Template.parse("{% if null == true %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if null == empty %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if null == blank %}?{% endif %}").render(), is(""));
+
+        assertThat(Template.parse("{% if blank == true %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if blank == empty %}?{% endif %}").render(), is(""));
+        assertThat(Template.parse("{% if blank == null %}?{% endif %}").render(), is(""));
     }
 }

--- a/src/test/java/liqp/parser/v4/LiquidLexerTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidLexerTest.java
@@ -68,7 +68,7 @@ public class LiquidLexerTest {
     }
 
     // mode IN_TAG;
-    // 
+    //
     //   OutStart2 : '{{' -> pushMode(IN_TAG);
     @Test
     public void testOutStart2() {
@@ -459,6 +459,13 @@ public class LiquidLexerTest {
         assertThat(tokenise("{{empty").get(1).getType(), is(LiquidLexer.Empty));
     }
 
+    //   Blank        : 'blank';
+    @Test
+    public void testBlank() {
+        assertThat(tokenise("{{blank").get(1).getType(), is(LiquidLexer.Blank));
+    }
+
+
     //   EndId        : 'end' Id;
     @Test
     public void testEndId() {
@@ -472,7 +479,7 @@ public class LiquidLexerTest {
     }
 
     // mode IN_RAW;
-    // 
+    //
     //   RawEnd : '{%' WhitespaceChar* 'endraw' -> popMode;
     @Test
     public void testRawEnd() {


### PR DESCRIPTION
Closes https://github.com/bkiers/Liqp/issues/147
The code contain new folder 'ruby' with ruby playground scripts and some useful helpers that allow to test the template native behavior either on liquid either on jekyll flavor via docker, so no need to install these libraries locally.  
Also update maven-surface-plugin so the travis wont fall. 