### PR TITLE
Jackson from 2.9.9 to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <antlr.version>3.5.1</antlr.version>
     <antlr4.version>4.7.2</antlr4.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
     <jsoup.version>1.11.3</jsoup.version>
     <junit.version>4.12</junit.version>
 


### PR DESCRIPTION
Security issue in Jackson 2.9.9: https://www.cybersecurity-help.cz/vdb/fasterxml/jackson-databind/2.9.9/?affChecked=1