### PR TITLE
Improved description of parsing errors

### DIFF
--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -403,7 +403,11 @@ public class Template {
             return rendered == null ? "" : String.valueOf(rendered);
         }
         catch (Exception e) {
-            throw new RuntimeException(e);
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -154,7 +154,7 @@ public class Template {
         lexer.addErrorListener(new BaseErrorListener(){
             @Override
             public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new LiquidException(String.format("lexer error on line %s, index %s", line, charPositionInLine), line, charPositionInLine);
+                throw new LiquidException(String.format("lexer error \"%s\" on line %s, index %s", msg, line, charPositionInLine), line, charPositionInLine, e);
             }
         });
 
@@ -166,7 +166,7 @@ public class Template {
         parser.addErrorListener(new BaseErrorListener(){
             @Override
             public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new LiquidException(String.format("parser error on line %s, index %s", line, charPositionInLine), line, charPositionInLine);
+                throw new LiquidException(String.format("parser error \"%s\" on line %s, index %s", msg, line, charPositionInLine), line, charPositionInLine, e);
             }
         });
 

--- a/src/main/java/liqp/exceptions/LiquidException.java
+++ b/src/main/java/liqp/exceptions/LiquidException.java
@@ -27,8 +27,8 @@ public class LiquidException extends RuntimeException {
     this.charPositionInLine = ctx.start.getCharPositionInLine();
   }
 
-  public LiquidException(String message, int line, int charPositionInLine) {
-    super(message);
+  public LiquidException(String message, int line, int charPositionInLine, Throwable cause) {
+    super(message, cause);
     this.line = line;
     this.charPositionInLine = charPositionInLine;
   }

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -134,7 +134,7 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeSubdirectorySpecifiedInLiquidFlavorWithStrictVariablesException() throws Exception {
 
-        thrown.expectCause(new NestedCauseMatcher<>(isA(VariableNotExistException.class)));
+        thrown.expectCause(isA(VariableNotExistException.class));
 
         File index = new File("src/test/jekyll/index_with_variables.html");
         Template template = Template.parse(


### PR DESCRIPTION
* ANTLRErrorListener callbacks from Lexer and Parser provide information about the error in parameter `msg`.
* RecognitionException message often contains additional details that are worth including as a `cause`.
    
Example for `Template.parse("Invalid {{end bracket} }")`: 
```
liqp.exceptions.LiquidException: lexer error "token recognition error at: '}'" on line 1, index 23
      Cause: LexerNoViableAltException('}')
```

Also simplified render exceptions    
* Most errors result in a RuntimeException, there is no need to wrap them in another RuntimeException.

Example `e.toString()`: Instead of previous version
```
java.lang.RuntimeException: java.lang.IllegalArgumentException: error on line 1, index 11: no filter available named: |invalidFilter
```
the exception becomes
```
java.lang.IllegalArgumentException: error on line 1, index 11: no filter available named: |invalidFilter
```
Note that obtaining/adding line number for render errors is more challenging. For the example above, it would require either parsing the exception, or replacing IllegalArgumentException with a different class. Many errors originate in a context where template line number is not knows (but perhaps could be added as the error bubbles up). I didn't address those issues here.
