### PR TITLE
Backward compatible exceptions

### DIFF
--- a/src/main/java/liqp/Examples.java
+++ b/src/main/java/liqp/Examples.java
@@ -1,6 +1,5 @@
 package liqp;
 
-import java.io.File;
 import liqp.filters.Filter;
 import liqp.nodes.LNode;
 import liqp.tags.Tag;
@@ -199,7 +198,55 @@ public class Examples {
                     .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
                     .render();
         } catch (RuntimeException ex) {
+            printExceptionWithCause(ex);
             System.out.println("Caught an exception for strict variables");
+        }
+    }
+
+    private static void demoParsingErrors() {
+        ParseSettings parseSettings = new ParseSettings.Builder().withShowInternalError(true).build();
+
+        try {
+            Template template = Template.parse("Invalid {{end bracket} }", parseSettings);
+        } catch (RuntimeException ex) {
+            printExceptionWithCause(ex);
+        }
+        try {
+            Template template = Template.parse("hi {%name}}", parseSettings);
+        } catch (RuntimeException ex) {
+            printExceptionWithCause(ex);
+        }
+    }
+
+    private static void demoRenderErrors() {
+        ParseSettings parseSettings = new ParseSettings.Builder().withShowInternalError(true).build();
+
+        try {
+            Template template = Template.parse("hi {{%name | invalidFilter}}", parseSettings);
+            String rendered = template.render("noname", "tobi");
+            System.out.println("If you see this then something is wrong!");
+        } catch (RuntimeException ex) {
+            printExceptionWithCause(ex);
+        }
+        try {
+            Template template = Template.parse("hi {{%name}}", parseSettings);
+            String rendered = template.render("{\"name\" : \"invalid_json\"");
+        } catch (RuntimeException ex) {
+            printExceptionWithCause(ex);
+        }
+        try {
+            Template template = Template.parse("{% include no_jekyll_here.html %}}", parseSettings);
+            String rendered = template.render();
+        } catch (RuntimeException ex) {
+            printExceptionWithCause(ex);
+        }
+    }
+
+    private static void printExceptionWithCause(Throwable ex) {
+        System.out.println(ex.toString());
+        while (ex.getCause() != null && ex.getCause() != ex) {
+            ex = ex.getCause();
+            System.out.println("    Cause: " + ex.toString());
         }
     }
 
@@ -230,6 +277,12 @@ public class Examples {
 
         System.out.println("\n=== demoStrictVariables() ===");
         demoStrictVariables();
+
+        System.out.println("\n=== demoParsingErrors() ===");
+        demoParsingErrors();
+
+        System.out.println("\n=== demoRenderErrors() ===");
+        demoRenderErrors();
 
         System.out.println("Done!");
     }

--- a/src/main/java/liqp/ParseSettings.java
+++ b/src/main/java/liqp/ParseSettings.java
@@ -8,6 +8,7 @@ public class ParseSettings {
     public final Flavor flavor;
     public final boolean stripSpacesAroundTags;
     public final boolean stripSingleLine;
+    public final boolean showInternalError;
     public final ObjectMapper mapper;
 
     public static class Builder {
@@ -15,11 +16,13 @@ public class ParseSettings {
         Flavor flavor;
         boolean stripSpacesAroundTags;
         boolean stripSingleLine;
+        boolean showInternalError;
         ObjectMapper mapper;
 
         public Builder() {
             this.flavor = Flavor.LIQUID;
             this.stripSpacesAroundTags = false;
+            this.showInternalError = false;
             this.mapper = new ObjectMapper();
         }
 
@@ -43,20 +46,26 @@ public class ParseSettings {
             return this;
         }
 
+        public Builder withShowInternalError(boolean showInternalError) {
+            this.showInternalError = showInternalError;
+            return this;
+        }
+
         public Builder withMapper(ObjectMapper mapper) {
             this.mapper = mapper;
             return this;
         }
 
         public ParseSettings build() {
-            return new ParseSettings(this.flavor, this.stripSpacesAroundTags, this.stripSingleLine, this.mapper);
+            return new ParseSettings(this.flavor, this.stripSpacesAroundTags, this.stripSingleLine, this.showInternalError, this.mapper);
         }
     }
 
-    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags, boolean stripSingleLine, ObjectMapper mapper) {
+    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags, boolean stripSingleLine, boolean showInternalError, ObjectMapper mapper) {
         this.flavor = flavor;
         this.stripSpacesAroundTags = stripSpacesAroundTags;
         this.stripSingleLine = stripSingleLine;
+        this.showInternalError = showInternalError;
         this.mapper = mapper;
     }
 }

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -403,7 +403,11 @@ public class Template {
             return rendered == null ? "" : String.valueOf(rendered);
         }
         catch (Exception e) {
-            throw new RuntimeException(e);
+            if (e instanceof RuntimeException) {
+                throw e;
+            } else {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -154,7 +154,7 @@ public class Template {
         lexer.addErrorListener(new BaseErrorListener(){
             @Override
             public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new LiquidException(String.format("lexer error on line %s, index %s", line, charPositionInLine), line, charPositionInLine);
+                throw new LiquidException(String.format("lexer error \"%s\" on line %s, index %s", msg, line, charPositionInLine), line, charPositionInLine, e);
             }
         });
 
@@ -166,7 +166,7 @@ public class Template {
         parser.addErrorListener(new BaseErrorListener(){
             @Override
             public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new LiquidException(String.format("parser error on line %s, index %s", line, charPositionInLine), line, charPositionInLine);
+                throw new LiquidException(String.format("parser error \"%s\" on line %s, index %s", msg, line, charPositionInLine), line, charPositionInLine, e);
             }
         });
 

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -75,11 +75,12 @@ public class Template {
         try {
             root = parse(lexer);
         }
-        catch (LiquidException e) {
-            throw e;
-        }
         catch (Exception e) {
-            throw new RuntimeException("could not parse input: " + input, e);
+            if (parseSettings.showInternalError && e instanceof RuntimeException) {
+                throw e;
+            } else {
+                throw new RuntimeException("could not parse input: " + input, e);
+            }
         }
     }
 
@@ -122,7 +123,11 @@ public class Template {
             root = parse(lexer);
         }
         catch (Exception e) {
-            throw new RuntimeException("could not parse input from " + file, e);
+            if (parseSettings.showInternalError && e instanceof RuntimeException) {
+                throw e;
+            } else {
+                throw new RuntimeException("could not parse input from " + file, e);
+            }
         }
     }
 
@@ -403,7 +408,7 @@ public class Template {
             return rendered == null ? "" : String.valueOf(rendered);
         }
         catch (Exception e) {
-            if (e instanceof RuntimeException) {
+            if (this.parseSettings.showInternalError && e instanceof RuntimeException) {
                 throw e;
             } else {
                 throw new RuntimeException(e);

--- a/src/main/java/liqp/exceptions/LiquidException.java
+++ b/src/main/java/liqp/exceptions/LiquidException.java
@@ -27,8 +27,8 @@ public class LiquidException extends RuntimeException {
     this.charPositionInLine = ctx.start.getCharPositionInLine();
   }
 
-  public LiquidException(String message, int line, int charPositionInLine) {
-    super(message);
+  public LiquidException(String message, int line, int charPositionInLine, Throwable cause) {
+    super(message, cause);
     this.line = line;
     this.charPositionInLine = charPositionInLine;
   }

--- a/src/test/java/liqp/TemplateTest.java
+++ b/src/test/java/liqp/TemplateTest.java
@@ -1,5 +1,6 @@
 package liqp;
 
+import liqp.exceptions.LiquidException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -84,6 +85,11 @@ public class TemplateTest {
     @Test(expected = RuntimeException.class)
     public void renderVarArgsTestInvalidKey2() throws RecognitionException {
         Template.parse("mu").render(null, 456);
+    }
+
+    @Test(expected = LiquidException.class)
+    public void renderInvalidTemplateShowInternalError() throws RecognitionException {
+        Template.parse("Invalid {{end bracket} }", new ParseSettings.Builder().withShowInternalError(true).build());
     }
 
     @Test

--- a/src/test/java/liqp/parser/ParseTest.java
+++ b/src/test/java/liqp/parser/ParseTest.java
@@ -1,5 +1,6 @@
 package liqp.parser;
 
+import liqp.ParseSettings;
 import liqp.Template;
 import liqp.exceptions.LiquidException;
 import org.junit.Test;
@@ -33,9 +34,14 @@ public class ParseTest {
      *   end
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void raise_on_single_close_bracetTest() throws Exception {
         Template.parse("text {{method} oh nos!");
+    }
+
+    @Test(expected=LiquidException.class)
+    public void raise_on_single_close_bracetTest_withShowInternalError() throws Exception {
+        Template.parse("text {{method} oh nos!", new ParseSettings.Builder().withShowInternalError(true).build());
     }
 
     /*
@@ -45,7 +51,7 @@ public class ParseTest {
      *   end
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void raise_on_label_and_no_close_bracetsTest() throws Exception {
         Template.parse("TEST {{ ");
     }
@@ -57,7 +63,7 @@ public class ParseTest {
      *   end
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void raise_on_label_and_no_close_bracets_percentTest() throws Exception {
         Template.parse("TEST {% ");
     }

--- a/src/test/java/liqp/tags/CaptureTest.java
+++ b/src/test/java/liqp/tags/CaptureTest.java
@@ -1,7 +1,6 @@
 package liqp.tags;
 
 import liqp.Template;
-import liqp.exceptions.LiquidException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
@@ -128,7 +127,7 @@ public class CaptureTest {
      *   end
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void capture_detects_bad_syntaxTest() throws Exception {
 
         Template.parse("{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}");

--- a/src/test/java/liqp/tags/CaseTest.java
+++ b/src/test/java/liqp/tags/CaseTest.java
@@ -1,7 +1,6 @@
 package liqp.tags;
 
 import liqp.Template;
-import liqp.exceptions.LiquidException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
@@ -312,12 +311,12 @@ public class CaseTest {
      *
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void case_detects_bad_syntax1Test() throws Exception {
         Template.parse("{% case false %}{% when %}true{% endcase %}");
     }
 
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void case_detects_bad_syntax2Test() throws Exception {
         Template.parse("{% case false %}{% huh %}true{% endcase %}");
     }

--- a/src/test/java/liqp/tags/IfTest.java
+++ b/src/test/java/liqp/tags/IfTest.java
@@ -1,7 +1,6 @@
 package liqp.tags;
 
 import liqp.Template;
-import liqp.exceptions.LiquidException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
@@ -341,7 +340,7 @@ public class IfTest {
      *   assert_raise(SyntaxError){ assert_template_result('', '{% if jerry == 1 %}')}
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void syntax_error_no_variableTest() throws RecognitionException {
         Template.parse("{% if jerry == 1 %}").render();
     }
@@ -351,7 +350,7 @@ public class IfTest {
      *   assert_raise(SyntaxError) { assert_template_result('', '{% if %}') }
      * end
      */
-    @Test(expected=LiquidException.class)
+    @Test(expected=RuntimeException.class)
     public void syntax_error_no_expressionTest() throws RecognitionException {
 
         Template.parse("{% if %}").render();

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -134,7 +134,7 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeSubdirectorySpecifiedInLiquidFlavorWithStrictVariablesException() throws Exception {
 
-        thrown.expectCause(isA(VariableNotExistException.class));
+        thrown.expectCause(new NestedCauseMatcher<>(isA(VariableNotExistException.class)));
 
         File index = new File("src/test/jekyll/index_with_variables.html");
         Template template = Template.parse(
@@ -143,6 +143,21 @@ public class IncludeTest {
             new RenderSettings.Builder().withStrictVariables(true).withShowExceptionsFromInclude(true).build());
         template.render();
     }
+
+    @Test
+    public void renderTestWithIncludeSubdirectorySpecifiedInLiquidFlavorWithShowInternalErrorWithStrictVariablesException() throws Exception {
+
+        thrown.expectCause(isA(VariableNotExistException.class));
+
+        File index = new File("src/test/jekyll/index_with_variables.html");
+        Template template = Template.parse(
+                index,
+                new ParseSettings.Builder().withFlavor(Flavor.LIQUID).withShowInternalError(true).build(),
+                new RenderSettings.Builder().withStrictVariables(true).withShowExceptionsFromInclude(true).build());
+        template.render();
+    }
+
+
 
     // https://github.com/bkiers/Liqp/issues/95
     @Test

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -134,7 +134,7 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeSubdirectorySpecifiedInLiquidFlavorWithStrictVariablesException() throws Exception {
 
-        thrown.expectCause(new NestedCauseMatcher<>(isA(VariableNotExistException.class)));
+        thrown.expectCause(isA(VariableNotExistException.class));
 
         File index = new File("src/test/jekyll/index_with_variables.html");
         Template template = Template.parse(


### PR DESCRIPTION
This PR adds additional commit on top of pull request #155, restoring behaviour of parsing exceptions for backward compatibility. New `ParseSettings.showInternalError` is required to throw `LiquidException`, as introduced with #153.
However, I doubt there are any implementations digging into exception hierarchies to obtain meaningful messages. Therefore, my suggestion is to
* accept PR #155, 
* **reject or ignore this PR**,
* release the library with a new minor number 0.8.X, indicating a minor incompatibility in the spirit of semantic versioning (this is debatable),
* return to this PR only if there are viable concerns about backward compatibility of exceptions from the community.
