### PR TITLE
Reverted eager evaluation of data model

### DIFF
--- a/src/main/java/liqp/Helper.java
+++ b/src/main/java/liqp/Helper.java
@@ -1,0 +1,26 @@
+package liqp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Map;
+
+public class Helper {
+
+    /**
+     * Prepare values (variables) for rendering the template.
+     * Input is transformed to JSON and back to a Java map.
+     *
+     * Note that double transformation is expensive. Transformation of large structures
+     * incurs considerable performance penalty. Use wisely!
+     *
+     * @param o Source of input variables. Typically a hierarchy of maps or POJO objects.
+     * @return a map containing only primitives (String, number, boolean), lists, and other maps
+     */
+    public static Map transformMap(Object o) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode oNode = objectMapper.convertValue(o, ObjectNode.class);
+        return objectMapper.convertValue(oNode, Map.class);
+    }
+
+}

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -393,13 +393,11 @@ public class Template {
                 variables.put(Include.INCLUDES_DIRECTORY_KEY, ((File) includeDirectory).getAbsolutePath());
             }
         }
-        ObjectNode value = parseSettings.mapper.convertValue(variables, ObjectNode.class);
-        Map map = parseSettings.mapper.convertValue(value, Map.class);
 
         final NodeVisitor visitor = new NodeVisitor(this.tags, this.filters, this.parseSettings);
         try {
             LNode node = visitor.visit(root);
-            Object rendered = node.render(new TemplateContext(protectionSettings, renderSettings, parseSettings, map));
+            Object rendered = node.render(new TemplateContext(protectionSettings, renderSettings, parseSettings, variables));
             return rendered == null ? "" : String.valueOf(rendered);
         }
         catch (Exception e) {

--- a/src/test/java/liqp/TemplateTest.java
+++ b/src/test/java/liqp/TemplateTest.java
@@ -1,5 +1,7 @@
 package liqp;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -89,7 +91,8 @@ public class TemplateTest {
     @Test
     public void renderMapWithPojosExistedNotRender() {
         Map<String, Object> data = new HashMap<String, Object>();
-        data.put("foo", new Foo());
+        //data.put("foo", new Foo());
+        data.put("foo", Helper.transformMap(new Foo()));
         data.put("bar", "zoo");
         data.put("bear", true);
 


### PR DESCRIPTION
Intention of this PR is to keep release `0.7.10` of the library compatible with versions prior to `0.7.9`.

* This commit reverts transformation of render variables to JSON and back to a Java map, introduced in commit 2eb6bc84.
Serialization to/from JSON brought incompatibility with library versions before 0.7.9,  and a considerable performance penalty (proportional to data model size).
*  If data transformation is needed (based on specific user situation), then the user has to transform the model outside the library. New method Helper.transformMap() was added for their convenience. For example:
    ` Template.render(Helper.transformMap(variables));`

Please refer to issue #162 discussing lazy vs. eager evaluation of data model. 

This is a forward-compatible change, made with an assumption that additional serialization mechanisms, data sanitations, or wrappers will be (likely) added to the library. Decision have to be made whether such mechanisms are invoked by default, or are optional (perhaps via RenderSettings).
In spirit of semantic versioning, I'd suggest to keep versions `0.7.X` compatible with lazy evaluation of data model. If eager evaluation/serialization will become default, then such code should be released as `0.8.X`.
