### PR TITLE
Added raiseExceptionsInStrictMode flag and recording errors

### DIFF
--- a/src/main/java/liqp/RenderSettings.java
+++ b/src/main/java/liqp/RenderSettings.java
@@ -39,22 +39,30 @@ public class RenderSettings {
 
     public final boolean strictVariables;
     public final boolean showExceptionsFromInclude;
+    public final boolean raiseExceptionsInStrictMode;
     public final EvaluateMode evaluateMode;
 
     public static class Builder {
 
         boolean strictVariables;
         boolean showExceptionsFromInclude;
+        boolean raiseExceptionsInStrictMode;
         EvaluateMode evaluateMode;
 
         public Builder() {
             this.strictVariables = false;
+            this.raiseExceptionsInStrictMode = true;
             this.evaluateMode = EvaluateMode.LAZY;
         }
 
         public Builder withStrictVariables(boolean strictVariables) {
             this.strictVariables = strictVariables;
             this.showExceptionsFromInclude = false;
+            return this;
+        }
+
+        public Builder withRaiseExceptionsInStrictMode(boolean raiseExceptionsInStrictMode) {
+            this.raiseExceptionsInStrictMode = raiseExceptionsInStrictMode;
             return this;
         }
 
@@ -69,13 +77,14 @@ public class RenderSettings {
         }
 
         public RenderSettings build() {
-            return new RenderSettings(this.strictVariables, this.showExceptionsFromInclude, this.evaluateMode);
+            return new RenderSettings(this.strictVariables, this.showExceptionsFromInclude, this.raiseExceptionsInStrictMode, this.evaluateMode);
         }
     }
 
-    private RenderSettings(boolean strictVariables, boolean showExceptionsFromInclude, EvaluateMode evaluateMode) {
+    private RenderSettings(boolean strictVariables, boolean showExceptionsFromInclude, boolean raiseExceptionsInStrictMode, EvaluateMode evaluateMode) {
         this.strictVariables = strictVariables;
         this.showExceptionsFromInclude = showExceptionsFromInclude;
+        this.raiseExceptionsInStrictMode = raiseExceptionsInStrictMode;
         this.evaluateMode = evaluateMode;
     }
 }

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -56,6 +56,8 @@ public class Template {
 
     private final ParseSettings parseSettings;
 
+    private TemplateContext templateContext = null;
+
     /**
      * Creates a new Template instance from a given input.
      *  @param input
@@ -288,6 +290,10 @@ public class Template {
         return this;
     }
 
+    public List<RuntimeException> errors() {
+        return this.templateContext == null ? new ArrayList<RuntimeException>() : this.templateContext.errors();
+    }
+
     /**
      * Renders the template.
      *
@@ -428,7 +434,8 @@ public class Template {
         final NodeVisitor visitor = new NodeVisitor(this.tags, this.filters, this.parseSettings);
         try {
             LNode node = visitor.visit(root);
-            Object rendered = node.render(new TemplateContext(protectionSettings, renderSettings, parseSettings, variables));
+            this.templateContext = new TemplateContext(protectionSettings, renderSettings, parseSettings, variables);
+            Object rendered = node.render(this.templateContext);
             return rendered == null ? "" : String.valueOf(rendered);
         }
         catch (Exception e) {

--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -2,7 +2,9 @@ package liqp;
 
 import liqp.parser.Flavor;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class TemplateContext {
@@ -12,6 +14,7 @@ public class TemplateContext {
     public final RenderSettings renderSettings;
     public final ParseSettings parseSettings;
     private Map<String, Object> variables;
+    private List<RuntimeException> errors;
 
     public TemplateContext() {
         this(new ProtectionSettings.Builder().build(),
@@ -32,11 +35,20 @@ public class TemplateContext {
         this.renderSettings = renderSettings;
         this.parseSettings = parseSettings;
         this.variables = new LinkedHashMap<>(variables);
+        this.errors = new ArrayList<>();
     }
 
     public TemplateContext(TemplateContext parent) {
         this(parent.protectionSettings, parent.renderSettings, parent.parseSettings, new LinkedHashMap<String, Object>());
         this.parent = parent;
+    }
+
+    public void addError(RuntimeException exception) {
+        this.errors.add(exception);
+    }
+
+    public List<RuntimeException> errors() {
+        return new ArrayList<>(this.errors);
     }
 
     public void incrementIterations() {

--- a/src/main/java/liqp/nodes/LookupNode.java
+++ b/src/main/java/liqp/nodes/LookupNode.java
@@ -42,7 +42,12 @@ public class LookupNode implements LNode {
         }
 
         if(value == null && context.renderSettings.strictVariables) {
-            throw new VariableNotExistException(getVariableName());
+            RuntimeException e = new VariableNotExistException(getVariableName());
+            context.addError(e);
+
+            if (context.renderSettings.raiseExceptionsInStrictMode) {
+                throw e;
+            }
         }
 
         return value;

--- a/src/test/java/liqp/RenderSettingsTest.java
+++ b/src/test/java/liqp/RenderSettingsTest.java
@@ -93,4 +93,24 @@ public class RenderSettingsTest {
             assertThat(e.getVariableName(), is("checkThis"));
         }
     }
+
+    @Test
+    public void raiseExceptionsInStrictModeFalseTest() {
+        RenderSettings renderSettings = new RenderSettings.Builder()
+                .withStrictVariables(true)
+                .withRaiseExceptionsInStrictMode(false)
+                .build();
+
+        Template template = Template.parse("{{a}}{{b}}{{c}}").withRenderSettings(renderSettings);
+
+        assertThat(template.errors().size(), is(0));
+
+        String rendered = template.render("b", "FOO");
+
+        // There should be 2 exceptions recorded for non-existing variables `a` and `c`
+        assertThat(template.errors().size(), is(2));
+
+        // Rendering should not terminate
+        assertThat(rendered, is("FOO"));
+    }
 }


### PR DESCRIPTION
When setting `RenderSettings.raiseExceptionsInStrictMode` to `false` (default set. tot `true`), then in strict mode, no exception will be thrown, but the exception will be recorded and can be retrieved by the method `Template.errors()`. This is exactly how Ruby's Liquid works.

Fixes #167 