### PR TITLE
Fix 179, Includes within for loop is missing variables

### DIFF
--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -120,4 +120,18 @@ public class TemplateContext {
     public Map<String,Object> getVariables() {
         return new LinkedHashMap<String, Object>(this.variables);
     }
+
+    /**
+     * @return all context variables, including those from parent.
+     */
+    public Map<String,Object> getAllVariables() {
+        Map<String, Object> allVariables;
+        if (parent!= null) {
+            allVariables = parent.getAllVariables();
+        } else {
+            allVariables = new LinkedHashMap<>();
+        }
+        allVariables.putAll(this.variables);
+        return allVariables;
+    }
 }

--- a/src/main/java/liqp/tags/For.java
+++ b/src/main/java/liqp/tags/For.java
@@ -55,7 +55,12 @@ class For extends Tag {
 
         nestedContext.put(FORLOOP, new HashMap<String, Object>());
 
-        Object rendered = array ? renderArray(id, nestedContext, nodes) : renderRange(id, nestedContext, nodes);
+        Object rendered;
+        if (array) {
+            rendered = renderArray(id, nestedContext, nodes);
+        } else {
+            rendered = renderRange(id, nestedContext, nodes);
+        }
 
         return rendered;
     }

--- a/src/main/java/liqp/tags/Include.java
+++ b/src/main/java/liqp/tags/Include.java
@@ -38,7 +38,7 @@ public class Include extends Tag {
                 context.put(includeResource, value);
             }
 
-            return template.render(context.getVariables());
+            return template.render(context.getAllVariables());
 
         } catch(Exception e) {
             if (context.renderSettings.showExceptionsFromInclude) {


### PR DESCRIPTION
Fix for https://github.com/bkiers/Liqp/issues/179
Include has access only to the variables of the current scope, so variables from parent scopes were missing. 
For the fixing this added a new method to TemplateContext that returns all variables, including parent's ones, recursive and used that as a source of data for include. The new collection is a clone, so the include will not have an impact on global variables. 

@bkiers, please review. 