### PR TITLE
Move Date filter closer to parity with Liquid implementation

### DIFF
--- a/src/main/java/liqp/filters/Date.java
+++ b/src/main/java/liqp/filters/Date.java
@@ -1,6 +1,7 @@
 package liqp.filters;
 
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -120,8 +121,7 @@ public class Date extends Filter {
                     SimpleDateFormat javaFormat = LIQUID_TO_JAVA_FORMAT.get(next);
 
                     if (javaFormat == null) {
-                        // no valid date-format: append the '%' and the 'next'-char
-                        builder.append("%").append(next);
+                        formatNonMappableChars(date, next, builder);
                     }
                     else {
                         builder.append(javaFormat.format(date));
@@ -174,6 +174,9 @@ public class Date extends Filter {
         // %e - Day of the month (1..31)
         LIQUID_TO_JAVA_FORMAT.put('e', new SimpleDateFormat("d", locale));
 
+        // %F - Year, month and day
+        LIQUID_TO_JAVA_FORMAT.put('F', new SimpleDateFormat("yyyy-MM-dd", locale));
+
         // %H - Hour of the day, 24-hour clock (00..23)
         LIQUID_TO_JAVA_FORMAT.put('H', new SimpleDateFormat("HH", locale));
 
@@ -195,11 +198,27 @@ public class Date extends Filter {
         // %M - Minute of the hour (00..59)
         LIQUID_TO_JAVA_FORMAT.put('M', new SimpleDateFormat("mm", locale));
 
+        // %n - Newline character
+        LIQUID_TO_JAVA_FORMAT.put('n', new SimpleDateFormat("\n", locale));
+
         // %p - Meridian indicator (``AM''  or  ``PM'')
         LIQUID_TO_JAVA_FORMAT.put('p', new SimpleDateFormat("a", locale));
+        LIQUID_TO_JAVA_FORMAT.put('P', new SimpleDateFormat("a", locale));
+
+        // %r - Time plus Meridian indicator (``12:00:00 PM'')
+        LIQUID_TO_JAVA_FORMAT.put('r', new SimpleDateFormat("hh:mm:ss a", locale));
+
+        // %R - Time without seconds (``12:00'')
+        LIQUID_TO_JAVA_FORMAT.put('R', new SimpleDateFormat("HH:mm", locale));
 
         // %S - Second of the minute (00..60)
         LIQUID_TO_JAVA_FORMAT.put('S', new SimpleDateFormat("ss", locale));
+
+        // %t - Tab character
+        LIQUID_TO_JAVA_FORMAT.put('t', new SimpleDateFormat("\t", locale));
+
+        // %T - Time with seconds (``12:00:00'')
+        LIQUID_TO_JAVA_FORMAT.put('T', new SimpleDateFormat("HH:mm:ss", locale));
 
         // %U - Week  number  of the current year,
         //      starting with the first Sunday as the first
@@ -210,21 +229,25 @@ public class Date extends Filter {
         //      starting with the first Monday as the first
         //      day of the first week (00..53)
         LIQUID_TO_JAVA_FORMAT.put('W', new SimpleDateFormat("ww", locale));
+        LIQUID_TO_JAVA_FORMAT.put('V', new SimpleDateFormat("ww", locale));
 
         // %w - Day of the week (Sunday is 0, 0..6)
         LIQUID_TO_JAVA_FORMAT.put('w', new SimpleDateFormat("F", locale));
 
         // %x - Preferred representation for the date alone, no time
         LIQUID_TO_JAVA_FORMAT.put('x', new SimpleDateFormat("MM/dd/yy", locale));
+        LIQUID_TO_JAVA_FORMAT.put('D', new SimpleDateFormat("MM/dd/yy", locale));
 
         // %X - Preferred representation for the time alone, no date
         LIQUID_TO_JAVA_FORMAT.put('X', new SimpleDateFormat("HH:mm:ss", locale));
 
         // %y - Year without a century (00..99)
         LIQUID_TO_JAVA_FORMAT.put('y', new SimpleDateFormat("yy", locale));
+        LIQUID_TO_JAVA_FORMAT.put('g', new SimpleDateFormat("yy", locale));
 
         // %Y - Year with century
         LIQUID_TO_JAVA_FORMAT.put('Y', new SimpleDateFormat("yyyy", locale));
+        LIQUID_TO_JAVA_FORMAT.put('G', new SimpleDateFormat("yyyy", locale));
 
         // %Z - Time zone name
         LIQUID_TO_JAVA_FORMAT.put('Z', new SimpleDateFormat("z", locale));
@@ -285,6 +308,30 @@ public class Date extends Filter {
 
         // Could not parse the string into a meaningful date, return null.
         return null;
+    }
+
+    /*
+     * Formats characters with no one-to-one mapping in SimpleDateFormat.
+     */
+    private void formatNonMappableChars(java.util.Date date, Character character, StringBuilder builder) {
+        Calendar calendar = Calendar.getInstance(locale);
+        calendar.setTime(date);
+        switch (character) {
+            case 'C':
+                int year = calendar.get(Calendar.YEAR);
+                builder.append(year / 100);
+                break;
+            case 's':
+                long epochSeconds = calendar.getTimeInMillis() / 1000L;
+                builder.append(epochSeconds);
+                break;
+            case 'u':
+                int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
+                builder.append(dayOfWeek - 1);
+                break;
+            default:
+                builder.append("%").append(character);
+        }
     }
 
     public interface CustomDateFormatSupport<T> {

--- a/src/test/java/liqp/filters/DateTest.java
+++ b/src/test/java/liqp/filters/DateTest.java
@@ -52,7 +52,18 @@ public class DateTest {
                 {"{{" + seconds + " | date: '%X'}}", simpleDateFormat("HH:mm:ss").format(date)},
                 {"{{" + seconds + " | date: 'x=%y'}}", "x=" + simpleDateFormat("yy").format(date)},
                 {"{{" + seconds + " | date: '%Y'}}", simpleDateFormat("yyyy").format(date)},
-                {"{{" + seconds + " | date: '%Z'}}", simpleDateFormat("z").format(date)}
+                {"{{" + seconds + " | date: '%Z'}}", simpleDateFormat("z").format(date)},
+                {"{{" + seconds + " | date: '%F'}}", simpleDateFormat("yyyy-MM-dd").format(date)},
+                {"{{" + seconds + " | date: '%n'}}", simpleDateFormat("\n").format(date)},
+                {"{{" + seconds + " | date: '%r'}}", simpleDateFormat("hh:mm:ss a").format(date)},
+                {"{{" + seconds + " | date: '%R'}}", simpleDateFormat("HH:mm").format(date)},
+                {"{{" + seconds + " | date: '%t'}}", simpleDateFormat("\t").format(date)},
+                {"{{" + seconds + " | date: '%T'}}", simpleDateFormat("HH:mm:ss").format(date)},
+                {"{{" + seconds + " | date: '%V'}}", simpleDateFormat("ww").format(date)},
+                {"{{" + seconds + " | date: '%D'}}", simpleDateFormat("MM/dd/yy").format(date)},
+                {"{{" + seconds + " | date: '%g'}}", simpleDateFormat("yy").format(date)},
+                {"{{" + seconds + " | date: '%G'}}", simpleDateFormat("yyyy").format(date)},
+                {"{{" + seconds + " | date: '%P'}}", simpleDateFormat("a").format(date)}
         };
 
         for (String[] test : tests) {
@@ -152,5 +163,20 @@ public class DateTest {
 
         // then
         assertThat(Filter.getFilter("date").apply(customDate, "%m/%d/%Y"), is((Object) "07/05/2006"));
+    }
+
+    @Test
+    public void testNonMappableCharacters() {
+        final int seconds = 946702800;
+
+        final String[] formats = {"%C", "%s", "%u", "%z"};
+        final String[] expected = {"19", "946702800", "5", "%z"};
+
+        int idx = 0;
+        for (String format : formats) {
+            Template template = Template.parse("{{" + seconds + " | date: '" + format + "'}}");
+            String rendered = String.valueOf(template.render());
+            assertThat(rendered, is(expected[idx++]));
+        }
     }
 }


### PR DESCRIPTION
- Adding support for the following format specifiers allowed by `strftime`:
-- D
-- F
-- g
-- G
-- n
-- P
-- r
-- R
-- t
-- T
-- V
-- C
-- s
-- u

