### PR TITLE
Date type support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*/.idea/
 .idea/
 *.iml
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>nl.big-o</groupId>
   <artifactId>liqp</artifactId>
   <packaging>jar</packaging>
-  <version>0.7.10-SNAPSHOT</version>
+  <version>0.8.00-alpha1-SNAPSHOT</version>
   <name>Liqp</name>
   <description>A Java implementation of the Liquid templating engine backed up by an ANTLR grammar.</description>
   <url>https://github.com/bkiers/Liqp</url>
@@ -51,7 +51,7 @@
 
     <antlr.version>3.5.1</antlr.version>
     <antlr4.version>4.7.2</antlr4.version>
-    <jackson.version>2.10.0</jackson.version>
+    <jackson.version>2.12.1</jackson.version>
     <jsoup.version>1.11.3</jsoup.version>
     <junit.version>4.13.1</junit.version>
 
@@ -86,9 +86,22 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+
+    <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <version>${jsoup.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ua.co.k</groupId>
+      <artifactId>strftime4j</artifactId>
+      <version>1.0.3</version>
     </dependency>
 
     <dependency>
@@ -141,8 +154,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>8</source>
+          <target>8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,16 @@
         <role>developer</role>
       </roles>
     </developer>
+    <developer>
+      <name>Vasyl Khrystiuk</name>
+      <email>h6.msangel@gmail.com</email>
+      <id>msangel</id>
+      <url>https://github.com/msangel</url>
+      <timezone>+2</timezone>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </developer>
   </developers>
 
   <distributionManagement>

--- a/ruby/_helpers.rb
+++ b/ruby/_helpers.rb
@@ -20,6 +20,10 @@ def assertEqual(expected, real)
   end
 end
 
+def assertTrue(real)
+  raise "{#{real}} is not true" unless real
+end
+
 def assert_equal(expected, real)
   assertEqual(expected, real)
 end

--- a/ruby/cases_date.rb
+++ b/ruby/cases_date.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+require 'pp'
+require_relative '_helpers.rb'
+require 'date'
+
+# pp "new date: %s" % Date.new
+# pp "new Time: %s" % Time.new
+# pp "now Time: %s" % Time.now
+
+# pp render({ "a" => Time.now }, "{{ a | date: '%Y'}}")
+
+tn = Time.now
+t = Time.new(2007,11,1,15,25,0, "+09:00")
+t_str = t.to_s
+
+# abs filter ignores fact the time is numeric
+# assertTrue(render({"a" => Time.now}, "{{ a | append: 'k' }}").end_with?("k"))
+# assertEqual("0", render({"a" => Time.now}, "{{ a | abs }}"))
+# assertEqual("-1", render({"a" => Time.now}, "{{ a | minus: 1 }}"))
+# assertEqual("0.3", render({ }, "{{  '0.2' | plus: '0.1' | abs }}"))
+# assertEqual("size of object: 2", render({ "a" => {"a" => 1, "b" => 2}}, "size of object: {{  a | size }}"))
+# assertEqual("size of date: 0", render({"a" => Time.now}, "size of date: {{ a | size }}"))
+# assertEqual("times: 6.3", render({ }, "times: {{ '2.1' | times:3 }}"))
+# assertEqual("times date: 0", render({"a" => Time.now}, "times date: {{ a | times:3 }}"))
+
+# assertEqual("true(2021-02-10 03:49:51 +0200)", render({"a" => Time.parse("2021-02-10 03:49:51"), "b" => Time.parse("2021-02-10 03:49:52")}, "{% if a and b %}true({{ a and b }}){% else %} false({{ a and b }}) {% endif %}"))
+# assertEqual("yes", render({ "a" => Time.now, "b" => Time.now - 90*24*60*60 }, "{% if a >= b %}yes{% else %}no{% endif %}"));
+# assertEqual("true", render({"true" => "bad"}, "{{true}}"))
+# assertEqual("false", render({"false" => "bad"}, "{{false}}"))
+# assertEqual("", render({"nil" => "bad"}, "{{nil}}"))
+# assertEqual("", render({"null" => "bad"}, "{{null}}"))
+# assertEqual("", render({"empty" => "bad"}, "{{empty}}"))
+# assertEqual("", render({"blank" => "bad"}, "{{blank}}"))
+assertEqual("2007-11-01...", render({"a" => t }, "{{ a | truncate: 13 }}"))
+
+if isJekyll
+
+  # target is string representation, source is iterated as collection(and so = match in "year" part)
+  assertEqual("target is string representation: 2007-11-01 15:25:00 +0900", render({"a" => [{ "time" => t }], "b" => "2007"}, "target is string representation: {{ a | where: 'time', b | map: 'time'}}"))
+
+
+  assertEqual(Time.now.to_s, render({"a" => [{ "time" => tn }], "b" => tn.year.to_s}, "{{ a | where: 'time', b | map: 'time'}}"))
+  assertRaise do
+    # time is not inspectable in ruby too...
+    # well, that is a bit more complicated:
+    # we iterate date as array of integers and strings (parts)
+    # and for each part we do index operator function with search property,
+    # which is always missing
+    # and so - is not resolve given property(till they are not
+    # numbers themself - in that case we do access bit at "index" position
+    #
+    render({"a" => t, "b" => "2007"}, "target is string representation: {{ a | where: 'time', b | map: 'time'}}")
+  end
+
+  # source is string representation that match the date
+  assertEqual("source is string representation: 2007-11-01 15:25:00 +0900", render({"a" => [{ "time" => t_str }], "b" => t},
+                                                                                   "source is string representation: {{ a | where: 'time', b | map: 'time'}}"))
+
+else # liquid
+  assertEqual("where in liquid respect only object equality : 2007-11-01 15:25:00 +0900", render({"a" => [{ "time" => t }], "b" => t}, "where in liquid respect only object equality : {{ a | where: 'time', b | map: 'time'}}"))
+  # same error: time is represented as array, but property reading from it fails
+  # pp render({"a" => t, "b" => t}, "where in liquid respect only object equality : {{ a | where: 'time', b | map: 'time'}}")
+end

--- a/src/main/java/liqp/ParseSettings.java
+++ b/src/main/java/liqp/ParseSettings.java
@@ -2,7 +2,9 @@ package liqp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import liqp.parser.Flavor;
+import liqp.spi.SPIHelper;
 
 public class ParseSettings {
 
@@ -24,6 +26,7 @@ public class ParseSettings {
             this.flavor = DEFAULT_FLAVOR;
             this.stripSpacesAroundTags = false;
             this.mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
             mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         }
 

--- a/src/main/java/liqp/RenderSettings.java
+++ b/src/main/java/liqp/RenderSettings.java
@@ -2,46 +2,53 @@ package liqp;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import liqp.parser.Inspectable;
 import liqp.parser.LiquidSupport;
 
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.TimeZone;
 
 public class RenderSettings {
 
-    public static final RenderSettings EXCEPTIONS_FROM_INCLUDE = new RenderSettings.Builder().withShowExceptionsFromInclude(true).build();
+    public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
 
     public enum EvaluateMode {
         LAZY,
         EAGER
     }
 
-    public Map<String, Object> evaluate(ObjectMapper mapper, Map<String, Object> variables) {
+
+    /**
+     * If template context is not available yet - it's ok to create new.
+     * This function don't need access to local context variables,
+     * as it operates with parameters.
+     */
+    public Map<String, Object> evaluate(final ObjectMapper mapper, Map<String, Object> variables) {
         if (evaluateMode == EvaluateMode.EAGER) {
-            ObjectNode value = mapper.convertValue(variables, ObjectNode.class);
-            return mapper.convertValue(value, Map.class);
+            return LiquidSupport.LiquidSupportFromInspectable.objectToMap(mapper, variables);
         }
         return variables;
     }
 
-    public LiquidSupport evaluate(final ObjectMapper mapper, final Inspectable variable) {
+    /**
+     * If template context is not available yet - it's ok to create new.
+     * This function don't need access to local context variables,
+     * as it operates with parameters.
+     */
+    public LiquidSupport evaluate(final ObjectMapper mapper, final Object variable) {
         if (variable instanceof LiquidSupport) {
             return ((LiquidSupport) variable);
         }
-        return new LiquidSupport() {
-            @Override
-            public Map<String, Object> toLiquid() {
-                ObjectNode value = mapper.convertValue(variable, ObjectNode.class);
-                return mapper.convertValue(value, Map.class);
-            }
-        };
+        return new LiquidSupport.LiquidSupportFromInspectable(mapper, variable);
     }
 
     public final boolean strictVariables;
     public final boolean showExceptionsFromInclude;
     public final boolean raiseExceptionsInStrictMode;
     public final EvaluateMode evaluateMode;
+    public final Locale locale;
+    public final TimeZone defaultTimeZone;
 
     public static class Builder {
 
@@ -49,11 +56,15 @@ public class RenderSettings {
         boolean showExceptionsFromInclude;
         boolean raiseExceptionsInStrictMode;
         EvaluateMode evaluateMode;
+        Locale locale;
+        TimeZone defaultTimeZone;
+
 
         public Builder() {
             this.strictVariables = false;
             this.raiseExceptionsInStrictMode = true;
             this.evaluateMode = EvaluateMode.LAZY;
+            this.locale = DEFAULT_LOCALE;
         }
 
         public Builder withStrictVariables(boolean strictVariables) {
@@ -77,15 +88,35 @@ public class RenderSettings {
             return this;
         }
 
+        public Builder withLocale(Locale locale){
+            Objects.requireNonNull(locale);
+            this.locale = locale;
+            return this;
+        }
+
+        /**
+         * Set default timezone for showing timezone of date/time types
+         * that does not have own timezone information.
+         * May be null, so the timezone pattern will be omitted in formatted strings.
+         * @param defaultTimeZone - value or <code>null<code/>
+         * @return
+         */
+        public Builder withDefaultTimeZone(TimeZone defaultTimeZone) {
+            this.defaultTimeZone = defaultTimeZone;
+            return this;
+        }
+
         public RenderSettings build() {
-            return new RenderSettings(this.strictVariables, this.showExceptionsFromInclude, this.raiseExceptionsInStrictMode, this.evaluateMode);
+            return new RenderSettings(this.strictVariables, this.showExceptionsFromInclude, this.raiseExceptionsInStrictMode, this.evaluateMode, this.locale, this.defaultTimeZone);
         }
     }
 
-    private RenderSettings(boolean strictVariables, boolean showExceptionsFromInclude, boolean raiseExceptionsInStrictMode, EvaluateMode evaluateMode) {
+    private RenderSettings(boolean strictVariables, boolean showExceptionsFromInclude, boolean raiseExceptionsInStrictMode, EvaluateMode evaluateMode, Locale locale, TimeZone defaultTimeZone) {
         this.strictVariables = strictVariables;
         this.showExceptionsFromInclude = showExceptionsFromInclude;
         this.raiseExceptionsInStrictMode = raiseExceptionsInStrictMode;
         this.evaluateMode = evaluateMode;
+        this.locale = locale;
+        this.defaultTimeZone = defaultTimeZone;
     }
 }

--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class TemplateContext {
 

--- a/src/main/java/liqp/filters/Abs.java
+++ b/src/main/java/liqp/filters/Abs.java
@@ -1,7 +1,26 @@
 package liqp.filters;
 
+import java.math.BigDecimal;
+
 public class Abs extends Filter {
 
+    /*
+    Everything that is not a number - cause this filter to return 0:
+    case obj
+      when Float
+        BigDecimal(obj.to_s)
+      when Numeric
+        obj
+      when String
+        (obj.strip =~ /\A-?\d+\.\d+\z/) ? BigDecimal(obj) : obj.to_i
+      else
+        if obj.respond_to?(:to_number)
+          obj.to_number
+        else
+          0
+        end
+      end
+     */
     @Override
     public Object apply(Object value, Object... params) {
 
@@ -10,9 +29,9 @@ public class Abs extends Filter {
         }
 
         if (super.isNumber(value) || super.canBeDouble(value)) {
-            return Math.abs(super.asNumber(value).doubleValue());
+            return asFormattedNumber(new BigDecimal(super.asNumber(value).toString()).abs());
         }
 
-        return value;
+        return 0;
     }
 }

--- a/src/main/java/liqp/filters/Date.java
+++ b/src/main/java/liqp/filters/Date.java
@@ -1,26 +1,22 @@
 package liqp.filters;
 
-import java.text.SimpleDateFormat;
-import java.util.HashSet;
+import liqp.LValue;
+import liqp.TemplateContext;
+import liqp.filters.date.CustomDateFormatRegistry;
+import liqp.filters.date.CustomDateFormatSupport;
+import liqp.filters.date.Parser;
+import ua.co.k.strftime.StrftimeFormatter;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Locale;
-import java.util.Set;
 
+import static liqp.filters.date.Parser.datePatterns;
+
+// general liquid info:
+// https://shopify.github.io/liquid/filters/date/
 public class Date extends Filter {
-
-    private static Locale locale = Locale.ENGLISH;
-    private static Set<String> datePatterns = new HashSet<String>();
-
-    private final static java.util.Map<Character, SimpleDateFormat> LIQUID_TO_JAVA_FORMAT =
-            new java.util.HashMap<Character, SimpleDateFormat>();
-
-    static {
-        addDatePattern("yyyy-MM-dd HH:mm:ss");
-        addDatePattern("EEE MMM dd hh:mm:ss yyyy");
-        init();
-    }
-
-    private CustomDateFormatSupport typeSupport;
-
 
     protected Date() {
         super();
@@ -28,216 +24,46 @@ public class Date extends Filter {
 
     protected Date(CustomDateFormatSupport typeSupport) {
         super();
-        this.typeSupport = typeSupport;
+        CustomDateFormatRegistry.add(typeSupport);
     }
 
-    /*
-     * (Object) date(input, format)
-     *
-     * Reformat a date
-     *
-     * %a - The abbreviated weekday name (``Sun'')
-     * %A - The  full  weekday  name (``Sunday'')
-     * %b - The abbreviated month name (``Jan'')
-     * %B - The  full  month  name (``January'')
-     * %c - The preferred local date and time representation
-     * %d - Day of the month (01..31)
-     * %e - Day of the month (1..31)
-     * %H - Hour of the day, 24-hour clock (00..23)
-     * %I - Hour of the day, 12-hour clock (01..12)
-     * %j - Day of the year (001..366)
-     * %k - Hour of the day, 24-hour clock (0..23)
-     * %l - Hour of the day, 12-hour clock (0..12)
-     * %m - Month of the year (01..12)
-     * %M - Minute of the hour (00..59)
-     * %p - Meridian indicator (``AM''  or  ``PM'')
-     * %S - Second of the minute (00..60)
-     * %U - Week  number  of the current year,
-     *      starting with the first Sunday as the first
-     *      day of the first week (00..53)
-     * %W - Week  number  of the current year,
-     *      starting with the first Monday as the first
-     *      day of the first week (00..53)
-     * %w - Day of the week (Sunday is 0, 0..6)
-     * %x - Preferred representation for the date alone, no time
-     * %X - Preferred representation for the time alone, no date
-     * %y - Year without a century (00..99)
-     * %Y - Year with century
-     * %Z - Time zone name
-     * %% - Literal ``%'' character
-     */
+
     @Override
-    public Object apply(Object value, Object... params) {
+    public Object apply(Object value, TemplateContext context, Object... params) {
+        Locale locale = context.renderSettings.locale;
 
+        if (isArray(value) && asArray(value).length ==1) {
+            value = asArray(value)[0];
+        }
         try {
-            final Long seconds;
-
-            if(super.asString(value).equals("now")) {
-                seconds = System.currentTimeMillis() / 1000L;
-            } else if (isCustomDateType(value)) {
-                seconds = getFromCustomType(value);
-            }
-            else if(super.isNumber(value)) {
+            final ZonedDateTime compatibleDate;
+            if ("now".equals(super.asString(value)) || "today".equals(super.asString(value))) {
+                compatibleDate = ZonedDateTime.now();
+            } else if (LValue.isTemporal(value)) {
+                compatibleDate = LValue.asTemporal(value);
+            } else if(super.isNumber(value)) {
                 // No need to divide this by 1000, the param is expected to be in seconds already!
-                seconds = super.asNumber(value).longValue();
+                compatibleDate = ZonedDateTime.ofInstant(Instant.ofEpochMilli(super.asNumber(value).longValue() * 1000), ZoneId.systemDefault());
+            } else {
+                compatibleDate = Parser.parse(super.asString(value), locale);
             }
-            else {
-                seconds = trySeconds(super.asString(value)); // formatter.parse(super.asString(value)).getTime() / 1000L;
-
-                if(seconds == null) {
-                    return value;
-                }
-            }
-
-            final java.util.Date date = new java.util.Date(seconds * 1000L);
-            final String format = super.asString(super.get(0, params));
-
-            if(format == null || format.trim().isEmpty()) {
+            if (compatibleDate == null) {
                 return value;
             }
 
-            final java.util.Calendar calendar = java.util.Calendar.getInstance();
-            calendar.setTime(date);
+            final String format = super.asString(super.get(0, params));
 
-            StringBuilder builder = new StringBuilder();
-
-            for (int i = 0; i < format.length(); i++) {
-
-                char ch = format.charAt(i);
-
-                if (ch == '%') {
-
-                    i++;
-
-                    if (i == format.length()) {
-                        // a trailing (single) '%' sign: just append it
-                        builder.append("%");
-                        break;
-                    }
-
-                    char next = format.charAt(i);
-
-                    SimpleDateFormat javaFormat = LIQUID_TO_JAVA_FORMAT.get(next);
-
-                    if (javaFormat == null) {
-                        // no valid date-format: append the '%' and the 'next'-char
-                        builder.append("%").append(next);
-                    }
-                    else {
-                        builder.append(javaFormat.format(date));
-                    }
-                }
-                else {
-                    builder.append(ch);
-                }
+            if(format == null || format.trim().isEmpty()) {
+                // todo: verify this
+                return value;
             }
 
-            return builder.toString();
+            StrftimeFormatter formatter = StrftimeFormatter.ofSafePattern(format, locale);
+            return formatter.format(compatibleDate);
         }
         catch (Exception e) {
             return value;
         }
-    }
-
-    private boolean isCustomDateType(Object value) {
-        return typeSupport != null && typeSupport.support(value);
-    }
-
-    private Long getFromCustomType(Object value) {
-        return typeSupport.getAsSeconds(value);
-    }
-
-    private static void init() {
-
-        // %% - Literal ``%'' character
-        LIQUID_TO_JAVA_FORMAT.put('%', new SimpleDateFormat("%", locale));
-
-        // %a - The abbreviated weekday name (``Sun'')
-        LIQUID_TO_JAVA_FORMAT.put('a', new SimpleDateFormat("EEE", locale));
-
-        // %A - The  full  weekday  name (``Sunday'')
-        LIQUID_TO_JAVA_FORMAT.put('A', new SimpleDateFormat("EEEE", locale));
-
-        // %b - The abbreviated month name (``Jan'')
-        LIQUID_TO_JAVA_FORMAT.put('b', new SimpleDateFormat("MMM", locale));
-        LIQUID_TO_JAVA_FORMAT.put('h', new SimpleDateFormat("MMM", locale));
-
-        // %B - The  full  month  name (``January'')
-        LIQUID_TO_JAVA_FORMAT.put('B', new SimpleDateFormat("MMMM", locale));
-
-        // %c - The preferred local date and time representation
-        LIQUID_TO_JAVA_FORMAT.put('c', new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", locale));
-
-        // %d - Day of the month (01..31)
-        LIQUID_TO_JAVA_FORMAT.put('d', new SimpleDateFormat("dd", locale));
-
-        // %e - Day of the month (1..31)
-        LIQUID_TO_JAVA_FORMAT.put('e', new SimpleDateFormat("d", locale));
-
-        // %H - Hour of the day, 24-hour clock (00..23)
-        LIQUID_TO_JAVA_FORMAT.put('H', new SimpleDateFormat("HH", locale));
-
-        // %I - Hour of the day, 12-hour clock (01..12)
-        LIQUID_TO_JAVA_FORMAT.put('I', new SimpleDateFormat("hh", locale));
-
-        // %j - Day of the year (001..366)
-        LIQUID_TO_JAVA_FORMAT.put('j', new SimpleDateFormat("DDD", locale));
-
-        // %k - Hour of the day, 24-hour clock (0..23)
-        LIQUID_TO_JAVA_FORMAT.put('k', new SimpleDateFormat("H", locale));
-
-        // %l - Hour of the day, 12-hour clock (1..12)
-        LIQUID_TO_JAVA_FORMAT.put('l', new SimpleDateFormat("h", locale));
-
-        // %m - Month of the year (01..12)
-        LIQUID_TO_JAVA_FORMAT.put('m', new SimpleDateFormat("MM", locale));
-
-        // %M - Minute of the hour (00..59)
-        LIQUID_TO_JAVA_FORMAT.put('M', new SimpleDateFormat("mm", locale));
-
-        // %p - Meridian indicator (``AM''  or  ``PM'')
-        LIQUID_TO_JAVA_FORMAT.put('p', new SimpleDateFormat("a", locale));
-
-        // %S - Second of the minute (00..60)
-        LIQUID_TO_JAVA_FORMAT.put('S', new SimpleDateFormat("ss", locale));
-
-        // %U - Week  number  of the current year,
-        //      starting with the first Sunday as the first
-        //      day of the first week (00..53)
-        LIQUID_TO_JAVA_FORMAT.put('U', new SimpleDateFormat("ww", locale));
-
-        // %W - Week  number  of the current year,
-        //      starting with the first Monday as the first
-        //      day of the first week (00..53)
-        LIQUID_TO_JAVA_FORMAT.put('W', new SimpleDateFormat("ww", locale));
-
-        // %w - Day of the week (Sunday is 0, 0..6)
-        LIQUID_TO_JAVA_FORMAT.put('w', new SimpleDateFormat("F", locale));
-
-        // %x - Preferred representation for the date alone, no time
-        LIQUID_TO_JAVA_FORMAT.put('x', new SimpleDateFormat("MM/dd/yy", locale));
-
-        // %X - Preferred representation for the time alone, no date
-        LIQUID_TO_JAVA_FORMAT.put('X', new SimpleDateFormat("HH:mm:ss", locale));
-
-        // %y - Year without a century (00..99)
-        LIQUID_TO_JAVA_FORMAT.put('y', new SimpleDateFormat("yy", locale));
-
-        // %Y - Year with century
-        LIQUID_TO_JAVA_FORMAT.put('Y', new SimpleDateFormat("yyyy", locale));
-
-        // %Z - Time zone name
-        LIQUID_TO_JAVA_FORMAT.put('Z', new SimpleDateFormat("z", locale));
-    }
-
-    /**
-     * Changes the locale.
-     *
-     * @param locale the new locale.
-     */
-    public static void setLocale(Locale locale) {
-        Date.locale = locale;
-        init();
     }
 
     /**
@@ -260,37 +86,7 @@ public class Date extends Filter {
      * @param pattern the pattern.
      */
     public static void removeDatePattern(String pattern) {
-
         datePatterns.remove(pattern);
-    }
-
-    /*
-     * Try to parse `str` into a Date and return this Date as seconds
-     * since EPOCH, or null if it could not be parsed.
-     */
-    private Long trySeconds(String str) {
-
-        for(String pattern : datePatterns) {
-
-            SimpleDateFormat parser = new SimpleDateFormat(pattern, locale);
-
-            try {
-                long milliseconds = parser.parse(str).getTime();
-                return milliseconds / 1000L;
-            }
-            catch(Exception e) {
-                // Just ignore and try the next pattern in `datePatterns`.
-            }
-        }
-
-        // Could not parse the string into a meaningful date, return null.
-        return null;
-    }
-
-    public interface CustomDateFormatSupport<T> {
-        Long getAsSeconds(T value);
-
-        boolean support(Object in);
     }
 
     public static Filter withCustomDateType(CustomDateFormatSupport typeSupport) {

--- a/src/main/java/liqp/filters/Map.java
+++ b/src/main/java/liqp/filters/Map.java
@@ -31,7 +31,7 @@ public class Map extends Filter {
 
             java.util.Map map;
             if (value instanceof Inspectable) {
-                LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) value);
+                LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, value);
                 map = evaluated.toLiquid();
             } else {
                 map = (java.util.Map) obj;

--- a/src/main/java/liqp/filters/Minus.java
+++ b/src/main/java/liqp/filters/Minus.java
@@ -1,5 +1,7 @@
 package liqp.filters;
 
+import java.math.BigDecimal;
+
 public class Minus extends Filter {
 
     /*
@@ -10,8 +12,8 @@ public class Minus extends Filter {
     @Override
     public Object apply(Object value, Object... params) {
 
-        if(value == null) {
-            value = 0L;
+        if (!isNumber(value)) {
+            value = 0;
         }
 
         super.checkParams(params, 1);
@@ -22,6 +24,8 @@ public class Minus extends Filter {
             return super.asNumber(value).longValue() - super.asNumber(rhsObj).longValue();
         }
 
-        return super.asNumber(value).doubleValue() - super.asNumber(rhsObj).doubleValue();
+        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        return asFormattedNumber(first.subtract(second));
     }
 }

--- a/src/main/java/liqp/filters/Modulo.java
+++ b/src/main/java/liqp/filters/Modulo.java
@@ -1,5 +1,7 @@
 package liqp.filters;
 
+import java.math.BigDecimal;
+
 public class Modulo extends Filter {
 
     /*
@@ -22,6 +24,8 @@ public class Modulo extends Filter {
             return super.asNumber(value).longValue() % super.asNumber(rhsObj).longValue();
         }
 
-        return super.asNumber(value).doubleValue() % super.asNumber(rhsObj).doubleValue();
+        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        return asFormattedNumber(first.remainder(second));
     }
 }

--- a/src/main/java/liqp/filters/Plus.java
+++ b/src/main/java/liqp/filters/Plus.java
@@ -1,5 +1,7 @@
 package liqp.filters;
 
+import java.math.BigDecimal;
+
 public class Plus extends Filter {
 
     /*
@@ -10,8 +12,8 @@ public class Plus extends Filter {
     @Override
     public Object apply(Object value, Object... params) {
 
-        if(value == null) {
-            value = 0L;
+        if (!isNumber(value)) {
+            value = 0;
         }
 
         super.checkParams(params, 1);
@@ -21,7 +23,8 @@ public class Plus extends Filter {
         if (super.canBeInteger(value) && super.canBeInteger(rhsObj)) {
             return super.asNumber(value).longValue() + super.asNumber(rhsObj).longValue();
         }
-
-        return super.asNumber(value).doubleValue() + super.asNumber(rhsObj).doubleValue();
+        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        return asFormattedNumber(first.add(second));
     }
 }

--- a/src/main/java/liqp/filters/Relative_Url.java
+++ b/src/main/java/liqp/filters/Relative_Url.java
@@ -84,7 +84,7 @@ public class Relative_Url extends Filter {
 
     protected Map<String, Object> objectToMap(Object configRoot, TemplateContext context) {
         if (configRoot instanceof Inspectable) {
-            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) configRoot);
+            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, configRoot);
             configRoot = evaluated.toLiquid();
         }
         Map<String, Object> siteMap;

--- a/src/main/java/liqp/filters/Size.java
+++ b/src/main/java/liqp/filters/Size.java
@@ -1,5 +1,9 @@
 package liqp.filters;
 
+import liqp.TemplateContext;
+import liqp.parser.Inspectable;
+import liqp.parser.LiquidSupport;
+
 public class Size extends Filter {
 
     /*
@@ -8,8 +12,16 @@ public class Size extends Filter {
      * Return the size of an array or of an string
      */
     @Override
-    public Object apply(Object value, Object... params) {
+    public Object apply(Object value, TemplateContext context, Object... params) {
 
+        if (value instanceof Inspectable) {
+            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, value);
+            value = evaluated.toLiquid();
+        }
+
+        if (isMap(value)) {
+            return asMap(value).size();
+        }
         if (super.isArray(value)) {
             return super.asArray(value).length;
         }

--- a/src/main/java/liqp/filters/Sort.java
+++ b/src/main/java/liqp/filters/Sort.java
@@ -5,7 +5,6 @@ import liqp.parser.Inspectable;
 import liqp.parser.LiquidSupport;
 
 import java.util.*;
-import java.util.Map;
 
 public class Sort extends Filter {
 
@@ -45,7 +44,7 @@ public class Sort extends Filter {
         for (Object obj : array) {
 
             if (property != null && obj instanceof Inspectable) {
-                LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) obj);
+                LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, obj);
                 obj = evaluated.toLiquid();
             }
             if(obj instanceof java.util.Map && property != null) {

--- a/src/main/java/liqp/filters/Times.java
+++ b/src/main/java/liqp/filters/Times.java
@@ -1,5 +1,9 @@
 package liqp.filters;
 
+import java.math.BigDecimal;
+
+import static java.math.BigDecimal.ROUND_UNNECESSARY;
+
 public class Times extends Filter {
 
     /*
@@ -22,6 +26,8 @@ public class Times extends Filter {
             return super.asNumber(value).longValue() * super.asNumber(rhsObj).longValue();
         }
 
-        return super.asNumber(value).doubleValue() * super.asNumber(rhsObj).doubleValue();
+        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        return asFormattedNumber(first.multiply(second));
     }
 }

--- a/src/main/java/liqp/filters/Where_Exp.java
+++ b/src/main/java/liqp/filters/Where_Exp.java
@@ -2,8 +2,6 @@ package liqp.filters;
 
 import liqp.Template;
 import liqp.TemplateContext;
-import liqp.filters.where.PropertyResolverAdapter;
-import liqp.filters.where.PropertyResolverHelper;
 import liqp.parser.Inspectable;
 import liqp.parser.LiquidSupport;
 
@@ -46,7 +44,7 @@ public class Where_Exp extends Filter {
         }
 
         if (items == null && value instanceof Inspectable) {
-            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) value);
+            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, value);
             value = evaluated.toLiquid();
         }
         if (isMap(value)) {
@@ -73,7 +71,7 @@ public class Where_Exp extends Filter {
     }
 
     private boolean matchCondition(TemplateContext context, Object item, String varName, Template expression) {
-        String res = expression.renderUnguarded(Collections.singletonMap(varName, item), context);
+        String res = expression.renderUnguarded(Collections.singletonMap(varName, item), context, false);
         return "true".equals(res);
     }
 }

--- a/src/main/java/liqp/filters/date/CustomDateFormatRegistry.java
+++ b/src/main/java/liqp/filters/date/CustomDateFormatRegistry.java
@@ -1,0 +1,44 @@
+package liqp.filters.date;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is a storage of supported types of Date/Time/DateTime types.
+ * Known types are static context.
+ */
+public class CustomDateFormatRegistry {
+
+    // might be better storage for this will be tree,
+    // so the subtypes will be properly handled
+    // and parent type will not override child's one
+    private static final List<CustomDateFormatSupport> supportedTypes = new ArrayList<>();
+
+    public static void add(CustomDateFormatSupport supportThis) {
+        supportedTypes.add(0, supportThis);
+    }
+
+
+    public static boolean isRegistered(CustomDateFormatSupport<?> typeSupport) {
+        return supportedTypes.contains(typeSupport);
+    }
+
+    public static boolean isCustomDateType(Object value) {
+        for (CustomDateFormatSupport el: supportedTypes) {
+            if (el.support(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static ZonedDateTime getFromCustomType(Object value) {
+        for (CustomDateFormatSupport el: supportedTypes) {
+            if (el.support(value)) {
+                return el.getValue(value);
+            }
+        }
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/liqp/filters/date/CustomDateFormatSupport.java
+++ b/src/main/java/liqp/filters/date/CustomDateFormatSupport.java
@@ -1,0 +1,8 @@
+package liqp.filters.date;
+
+import java.time.ZonedDateTime;
+
+public interface CustomDateFormatSupport<T> {
+    ZonedDateTime getValue(T value);
+    boolean support(Object in);
+}

--- a/src/main/java/liqp/filters/date/Parser.java
+++ b/src/main/java/liqp/filters/date/Parser.java
@@ -1,0 +1,104 @@
+package liqp.filters.date;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQueries;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+public class Parser {
+
+    /**
+     * In case if anyone interesting about full set
+     * of supported by ruby date patterns:
+     * there no such set as the parsing there happening based on
+     * heuristic algorithms.
+     * This is how it looks like(~3K lines just for date parse):
+     * https://github.com/ruby/ruby/blob/ee102de6d7ec2454dc5da223483737478eb7bcc7/ext/date/date_parse.c
+     *
+     * And here's python.
+     * Just an example how it is violating standard in details regarding timezone representation:
+     * https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
+     */
+    public static List<String> datePatterns = new ArrayList<>();
+
+    static {
+        datePatterns.add("yyyy-MM-dd HH:mm:ss");
+        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss");
+        datePatterns.add("yyyy-MM-dd HH:mm:ss Z");
+        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss Z");
+        datePatterns.add("yyyy-MM-dd HH:mm:ss X");
+        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss X");
+        datePatterns.add("yyyy-MM-dd HH:mm:ss z");
+        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss z");
+        datePatterns.add("EEE MMM dd hh:mm:ss yyyy");
+    }
+
+    public static ZonedDateTime parse(String str, Locale locale) {
+
+        for(String pattern : datePatterns) {
+            try {
+
+                DateTimeFormatter timeFormatter = new DateTimeFormatterBuilder()
+                        .parseCaseInsensitive()
+                        .appendPattern(pattern)
+                        .toFormatter(locale);
+
+                TemporalAccessor temporalAccessor = timeFormatter.parse(str);
+                return getZonedDateTimeFromTemporalAccessor(temporalAccessor);
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+
+        // Could not parse the string into a meaningful date, return null.
+        return null;
+    }
+
+    /**
+     * Follow ruby rules: if some datetime part is missing,
+     * the default is taken from `now` with default zone
+     */
+    public static ZonedDateTime getZonedDateTimeFromTemporalAccessor(TemporalAccessor temporalAccessor) {
+        if (temporalAccessor instanceof ZonedDateTime) {
+            return (ZonedDateTime) temporalAccessor;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        TemporalField[] copyThese = new TemporalField[]{
+                YEAR,
+                MONTH_OF_YEAR,
+                DAY_OF_MONTH,
+                HOUR_OF_DAY,
+                MINUTE_OF_HOUR,
+                SECOND_OF_MINUTE,
+                NANO_OF_SECOND
+        };
+        for (TemporalField tf: copyThese) {
+            if (temporalAccessor.isSupported(tf)) {
+                now = now.with(tf, temporalAccessor.get(tf));
+            }
+        }
+
+        ZoneId zoneId = temporalAccessor.query(TemporalQueries.zone());
+        if (zoneId == null) {
+            zoneId = ZoneId.systemDefault();
+        }
+
+        return now.atZone(zoneId);
+    }
+}

--- a/src/main/java/liqp/filters/where/LiquidWhereImpl.java
+++ b/src/main/java/liqp/filters/where/LiquidWhereImpl.java
@@ -3,6 +3,7 @@ package liqp.filters.where;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import liqp.TemplateContext;
+import liqp.spi.BasicTypesSupport;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;

--- a/src/main/java/liqp/filters/where/PropertyResolverHelper.java
+++ b/src/main/java/liqp/filters/where/PropertyResolverHelper.java
@@ -7,6 +7,7 @@ import liqp.parser.LiquidSupport;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PropertyResolverHelper {
     private final List<PropertyResolverAdapter> propertyResolverAdapters;
@@ -20,13 +21,24 @@ public class PropertyResolverHelper {
             private final LValue lValue = new LValue() {};
             @Override
             public Object getItemProperty(TemplateContext context, Object input, Object property) {
-                LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) input);
+                LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, input);
                 return evaluated.toLiquid().get(lValue.asString(property));
             }
 
             @Override
             public boolean support(Object target) {
                 return target instanceof Inspectable;
+            }
+        });
+        INSTANCE.add(new PropertyResolverAdapter() {
+            @Override
+            public Object getItemProperty(TemplateContext context, Object input, Object property) {
+                return ((Map)input).get(property);
+            }
+
+            @Override
+            public boolean support(Object target) {
+                return target instanceof Map;
             }
         });
     }

--- a/src/main/java/liqp/nodes/AtomNode.java
+++ b/src/main/java/liqp/nodes/AtomNode.java
@@ -4,8 +4,18 @@ import liqp.TemplateContext;
 
 public class AtomNode implements LNode {
 
-    public static final AtomNode EMPTY = new AtomNode(new Object());
-    public static final AtomNode BLANK = new AtomNode(new Object());
+    public static final AtomNode EMPTY = new AtomNode(new Object() {
+        @Override
+        public String toString() {
+            return "";
+        }
+    });
+    public static final AtomNode BLANK = new AtomNode(new Object() {
+        @Override
+        public String toString() {
+            return "";
+        }
+    });
 
     private Object value;
 

--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -1,13 +1,16 @@
 package liqp.nodes;
 
+import liqp.TemplateContext;
+
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import liqp.TemplateContext;
-import liqp.tags.Tag;
-
 import static liqp.LValue.BREAK;
 import static liqp.LValue.CONTINUE;
+import static liqp.LValue.asTemporal;
+import static liqp.LValue.isTemporal;
+import static liqp.LValue.rubyDateTimeFormat;
 
 public class BlockNode implements LNode {
 
@@ -46,25 +49,21 @@ public class BlockNode implements LNode {
 
             if(value == BREAK || value == CONTINUE) {
                 return value;
-            }
-            else if (value instanceof List) {
+            } else if (value instanceof List) {
 
-                List list = (List) value;
+                List<?> list = (List<?>) value;
 
                 for (Object obj : list) {
-                    builder.append(String.valueOf(obj));
+                    builder.append(asString(obj));
                 }
-            }
-            else if (value.getClass().isArray()) {
+            } else if (value.getClass().isArray()) {
 
                 Object[] array = (Object[]) value;
-
                 for (Object obj : array) {
-                    builder.append(String.valueOf(obj));
+                    builder.append(asString(obj));
                 }
-            }
-            else {
-                builder.append(String.valueOf(value));
+            } else {
+                builder.append(asString(value));
             }
 
             if (builder.length() > context.protectionSettings.maxSizeRenderedString) {
@@ -73,5 +72,14 @@ public class BlockNode implements LNode {
         }
 
         return builder.toString();
+    }
+
+    private String asString(Object value) {
+        if (isTemporal(value)) {
+            ZonedDateTime time = asTemporal(value);
+            return rubyDateTimeFormat.format(time);
+        } else {
+            return String.valueOf(value);
+        }
     }
 }

--- a/src/main/java/liqp/nodes/ContainsNode.java
+++ b/src/main/java/liqp/nodes/ContainsNode.java
@@ -27,7 +27,7 @@ public class ContainsNode extends LValue implements LNode {
         Object needle = rhs.render(context);
 
         if (collection instanceof Inspectable) {
-            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) collection);
+            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, collection);
             collection = evaluated.toLiquid();
         }
 
@@ -51,7 +51,7 @@ public class ContainsNode extends LValue implements LNode {
 
     private Object toSingleNumberType(Object needle) {
         if (needle instanceof Number) {
-            needle = new BigDecimal(needle.toString()).stripTrailingZeros();
+            needle = LValue.asFormattedNumber(new BigDecimal(needle.toString()));
         }
         return needle;
     }
@@ -60,7 +60,7 @@ public class ContainsNode extends LValue implements LNode {
         ArrayList<Object> res = new ArrayList<>(asList.size());
         for(Object item: asList) {
             if (item instanceof Number) {
-                res.add(new BigDecimal(item.toString()).stripTrailingZeros());
+                res.add(LValue.asFormattedNumber(new BigDecimal(item.toString())));
             } else {
                 res.add(item);
             }

--- a/src/main/java/liqp/nodes/FilterNode.java
+++ b/src/main/java/liqp/nodes/FilterNode.java
@@ -2,6 +2,7 @@ package liqp.nodes;
 
 import liqp.TemplateContext;
 import liqp.filters.Filter;
+import liqp.spi.BasicTypesSupport;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 import java.util.ArrayList;
@@ -44,8 +45,7 @@ public class FilterNode implements LNode {
             for (LNode node : params) {
                 paramValues.add(node.render(context));
             }
-
-            return filter.apply(value, context, paramValues.toArray(new Object[paramValues.size()]));
+            return filter.apply(value, context, paramValues.toArray(new Object[0]));
         }
         catch (Exception e) {
             throw new RuntimeException("error on line " + line + ", index " + tokenStartIndex + ": " + e.getMessage(), e);

--- a/src/main/java/liqp/nodes/GtEqNode.java
+++ b/src/main/java/liqp/nodes/GtEqNode.java
@@ -5,8 +5,8 @@ import liqp.TemplateContext;
 
 public class GtEqNode extends LValue implements LNode {
 
-    private LNode lhs;
-    private LNode rhs;
+    private final LNode lhs;
+    private final LNode rhs;
 
     public GtEqNode(LNode lhs, LNode rhs) {
         this.lhs = lhs;
@@ -18,7 +18,20 @@ public class GtEqNode extends LValue implements LNode {
 
         Object a = lhs.render(context);
         Object b = rhs.render(context);
+        if (isTemporal(a)) {
+            a = asTemporal(a);
+        }
+        if (isTemporal(b)) {
+            b = asTemporal(b);
+        }
 
+        if (a instanceof Comparable && a.getClass().isInstance(b)) {
+            return ((Comparable) a).compareTo(b) >= 0;
+        } else if (b instanceof Comparable && b.getClass().isInstance(a)) {
+            return ((Comparable) b).compareTo(a) < 0;
+        }
+
+        // different number class so use this convertion
         return (a instanceof Number) && (b instanceof Number) &&
                 super.asNumber(a).doubleValue() >= super.asNumber(b).doubleValue();
     }

--- a/src/main/java/liqp/nodes/GtNode.java
+++ b/src/main/java/liqp/nodes/GtNode.java
@@ -19,6 +19,19 @@ public class GtNode extends LValue implements LNode {
         Object a = lhs.render(context);
         Object b = rhs.render(context);
 
+        if (isTemporal(a)) {
+            a = asTemporal(a);
+        }
+        if (isTemporal(b)) {
+            b = asTemporal(b);
+        }
+
+        if (a instanceof Comparable && a.getClass().isInstance(b)) {
+            return ((Comparable) a).compareTo(b) > 0;
+        } else if (b instanceof Comparable && b.getClass().isInstance(a)) {
+            return ((Comparable) b).compareTo(a) <= 0;
+        }
+
         return (a instanceof Number) && (b instanceof Number) &&
                 super.asNumber(a).doubleValue() > super.asNumber(b).doubleValue();
     }

--- a/src/main/java/liqp/nodes/LookupNode.java
+++ b/src/main/java/liqp/nodes/LookupNode.java
@@ -96,7 +96,7 @@ public class LookupNode implements LNode {
                 else if(value instanceof java.util.Map || value instanceof Inspectable) {
                     java.util.Map map;
                     if (value instanceof Inspectable) {
-                        LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) value);
+                        LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, value);
                         map = evaluated.toLiquid();
                     } else {
                         map = (java.util.Map) value;
@@ -135,7 +135,7 @@ public class LookupNode implements LNode {
             if(value instanceof java.util.Map || value instanceof Inspectable) {
                 java.util.Map map;
                 if (value instanceof Inspectable) {
-                    LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) value);
+                    LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, value);
                     map = evaluated.toLiquid();
                 } else {
                     map = (java.util.Map) value;
@@ -159,10 +159,12 @@ public class LookupNode implements LNode {
     public static class Index implements Indexable {
 
         private final LNode expression;
+        private final String text;
         private Object key = null;
 
-        public Index(LNode expression) {
+        public Index(LNode expression, String text) {
             this.expression = expression;
+            this.text = text;
         }
 
         @Override
@@ -202,7 +204,7 @@ public class LookupNode implements LNode {
         @Override
         public String toString() {
 
-            return String.format("[%s]", key);
+            return String.format("[%s]", text);
         }
     }
 

--- a/src/main/java/liqp/nodes/LtEqNode.java
+++ b/src/main/java/liqp/nodes/LtEqNode.java
@@ -19,6 +19,19 @@ public class LtEqNode extends LValue implements LNode {
         Object a = lhs.render(context);
         Object b = rhs.render(context);
 
+        if (isTemporal(a)) {
+            a = asTemporal(a);
+        }
+        if (isTemporal(b)) {
+            b = asTemporal(b);
+        }
+
+        if (a instanceof Comparable && a.getClass().isInstance(b)) {
+            return ((Comparable) a).compareTo(b) <= 0;
+        } else if (b instanceof Comparable && b.getClass().isInstance(a)) {
+            return ((Comparable) b).compareTo(a) > 0;
+        }
+
         return (a instanceof Number) && (b instanceof Number) &&
                 super.asNumber(a).doubleValue() <= super.asNumber(b).doubleValue();
     }

--- a/src/main/java/liqp/nodes/LtNode.java
+++ b/src/main/java/liqp/nodes/LtNode.java
@@ -19,6 +19,19 @@ public class LtNode extends LValue implements LNode {
         Object a = lhs.render(context);
         Object b = rhs.render(context);
 
+        if (isTemporal(a)) {
+            a = asTemporal(a);
+        }
+        if (isTemporal(b)) {
+            b = asTemporal(b);
+        }
+
+        if (a instanceof Comparable && a.getClass().isInstance(b)) {
+            return ((Comparable) a).compareTo(b) < 0;
+        } else if (b instanceof Comparable && b.getClass().isInstance(a)) {
+            return ((Comparable) b).compareTo(a) >= 0;
+        }
+
         return (a instanceof Number) && (b instanceof Number) &&
                 super.asNumber(a).doubleValue() < super.asNumber(b).doubleValue();
     }

--- a/src/main/java/liqp/parser/LiquidSupport.java
+++ b/src/main/java/liqp/parser/LiquidSupport.java
@@ -1,11 +1,18 @@
 package liqp.parser;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import liqp.TemplateContext;
+import liqp.spi.BasicTypesSupport;
+import liqp.spi.SPIHelper;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -55,5 +62,60 @@ public interface LiquidSupport extends Inspectable {
             Map<String, Object> data = item.toLiquid();
             jsgen.writeObject(data);
         }
+    }
+
+    /**
+     * The implementation of converter from Inspectable to LiquidSupport.
+     */
+    class LiquidSupportFromInspectable implements LiquidSupport {
+        public static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<Map<String, Object>>() {};
+        private final ObjectMapper mapper;
+        private final Object variable;
+
+        public LiquidSupportFromInspectable(ObjectMapper mapper, Object variable) {
+            this.variable = variable;
+            this.mapper = mapper;
+        }
+
+        public static Map<String, Object> objectToMap(ObjectMapper mapper, Object variables) {
+            if (mapper == null) {
+                throw new RuntimeException("ObjectMapper required here");
+            }
+            ObjectMapper copy = SPIHelper.applyTypeReferencing(mapper.copy());
+            ObjectNode value = copy.convertValue(variables, ObjectNode.class);
+            Map<String, Object> convertedValue = copy.convertValue(value, MAP_TYPE_REF);
+            visitMap(convertedValue);
+            return convertedValue;
+        }
+
+        @Override
+        public Map<String, Object> toLiquid() {
+            return objectToMap(mapper, variable);
+        }
+
+        static void visitMap(Map<?, ?> map) {
+            for (Map.Entry entry: map.entrySet()) {
+                Object value = BasicTypesSupport.restoreObject(entry.getValue());
+                visit(value);
+                entry.setValue(value);
+            }
+        }
+        static void visitList(List list) {
+            for (int i = 0; i< list.size(); i++) {
+                Object object = list.get(i);
+                Object value = BasicTypesSupport.restoreObject(object);
+                visit(value);
+                //noinspection unchecked
+                list.set(i, value);
+            }
+        }
+        static void visit(Object object) {
+            if (object instanceof Map) {
+                visitMap((Map)object);
+            } if (object instanceof List) {
+                visitList((List)object);
+            }
+        }
+
     }
 }

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -697,7 +697,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
         node.add(new LookupNode.Hash(index.id2().getText()));
       }
       else {
-        node.add(new LookupNode.Index(visit(index.expr())));
+        node.add(new LookupNode.Index(visit(index.expr()), index.expr().getText()));
       }
     }
 

--- a/src/main/java/liqp/spi/BasicTypesSupport.java
+++ b/src/main/java/liqp/spi/BasicTypesSupport.java
@@ -1,0 +1,73 @@
+package liqp.spi;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import liqp.filters.date.CustomDateFormatRegistry;
+import liqp.filters.date.CustomDateFormatSupport;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class BasicTypesSupport implements TypesSupport {
+
+    private static ThreadLocal<Map<String, Object>> local = ThreadLocal.withInitial(ConcurrentHashMap::new);
+
+    
+    protected<T> void registerType(SimpleModule module, final Class<T> clazz) {
+        // we put the ref to object here for restoring it by the ref later
+        // so we will preserve the object in case of eager evaluation
+        // and will put it back when needed
+        module.addSerializer(new StdSerializer<T>(clazz) {
+            @Override
+            public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+                gen.writeStartObject();
+                gen.writeBooleanField("@supportedTypeMarker", true);
+                gen.writeStringField("@ref", createReference(value));
+                gen.writeEndObject();
+            }
+        });
+    }
+
+    protected void addCustomDateType(CustomDateFormatSupport typeSupport) {
+        if (!CustomDateFormatRegistry.isRegistered(typeSupport)) {
+            CustomDateFormatRegistry.add(typeSupport);
+        }
+    }
+
+    public static Object restoreObject(Object obj) {
+        if (! (obj instanceof Map)) {
+            return obj;
+        }
+        //noinspection rawtypes
+        Map mapObj = (Map) obj;
+        if (!Boolean.TRUE.equals(mapObj.get("@supportedTypeMarker"))) {
+            return obj;
+        }
+        Object ref = mapObj.get("@ref");
+        if (!(ref instanceof String)) {
+            // improperly formatted objects will be returned as is
+            return obj;
+        }
+        return getByReference((String) ref);
+    }
+
+
+
+    public static String createReference(Object obj) {
+        String key = Thread.currentThread().hashCode() + ":" + System.currentTimeMillis() + ":" + obj.hashCode();
+        local.get().put(key, obj);
+        return key;
+    }
+
+    public static <TT> TT getByReference(String key) {
+        return (TT)local.get().remove(key);
+    }
+
+    public static void clearReferences(){
+        local.get().clear();
+    }
+
+}

--- a/src/main/java/liqp/spi/Java7DateTypesSupport.java
+++ b/src/main/java/liqp/spi/Java7DateTypesSupport.java
@@ -1,0 +1,49 @@
+package liqp.spi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import liqp.filters.date.CustomDateFormatSupport;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+
+public class Java7DateTypesSupport extends BasicTypesSupport {
+
+    @Override
+    public void configureTypesForReferencing(ObjectMapper mapper) {
+        SimpleModule module = new SimpleModule("liqp java 7 date type support");
+        registerType(module, Date.class);
+        registerType(module, Calendar.class);
+        mapper.registerModule(module);
+    }
+
+    @Override
+    public void configureCustomDateTypes() {
+        addCustomDateType(new CustomDateFormatSupport<Date>() {
+
+            @Override
+            public ZonedDateTime getValue(Date value) {
+                return ZonedDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
+            }
+
+            @Override
+            public boolean support(Object in) {
+                return in instanceof Date;
+            }
+        });
+
+        addCustomDateType(new CustomDateFormatSupport<Calendar>() {
+            @Override
+            public ZonedDateTime getValue(Calendar value) {
+                return ZonedDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
+            }
+
+            @Override
+            public boolean support(Object in) {
+                return in instanceof Calendar;
+            }
+        });
+    }
+}

--- a/src/main/java/liqp/spi/Java8DateTypesSupport.java
+++ b/src/main/java/liqp/spi/Java8DateTypesSupport.java
@@ -1,0 +1,26 @@
+package liqp.spi;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import liqp.TemplateContext;
+import liqp.filters.date.CustomDateFormatSupport;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.Map;
+
+
+public class Java8DateTypesSupport extends BasicTypesSupport {
+    @Override
+    public void configureTypesForReferencing(ObjectMapper mapper) {
+        SimpleModule module = new SimpleModule("liqp java 8 date type support");
+        registerType(module, Temporal.class);
+        mapper.registerModule(module);
+    }
+}

--- a/src/main/java/liqp/spi/SPIHelper.java
+++ b/src/main/java/liqp/spi/SPIHelper.java
@@ -1,0 +1,46 @@
+package liqp.spi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class SPIHelper {
+
+    private static volatile List<TypesSupport> typeSupporters;
+
+    public static ObjectMapper applyTypeReferencing(ObjectMapper mapper) {
+        List<TypesSupport> providers = findProviders();
+        for (TypesSupport el: providers) {
+            el.configureTypesForReferencing(mapper);
+        }
+        return mapper;
+    }
+
+    public static void applyCustomDateTypes() {
+        List<TypesSupport> providers = findProviders();
+        for (TypesSupport el: providers) {
+            el.configureCustomDateTypes();
+        }
+    }
+    
+    
+
+    private static List<TypesSupport> findProviders() {
+        if (typeSupporters == null) {
+            ServiceLoader<TypesSupport> loader = ServiceLoader.load(TypesSupport.class);
+            typeSupporters = copyIterator(loader.iterator());
+        }
+        return typeSupporters;
+    }
+
+    private static <T> List<T> copyIterator(Iterator<T> iter) {
+        List<T> copy = new ArrayList<T>();
+        while (iter.hasNext()) {
+            copy.add(iter.next());
+        }
+        return copy;
+    }
+}

--- a/src/main/java/liqp/spi/TypesSupport.java
+++ b/src/main/java/liqp/spi/TypesSupport.java
@@ -1,0 +1,10 @@
+package liqp.spi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public interface TypesSupport {
+    void configureTypesForReferencing(ObjectMapper mapper);
+    default void configureCustomDateTypes() {
+        
+    }
+}

--- a/src/main/java/liqp/tags/For.java
+++ b/src/main/java/liqp/tags/For.java
@@ -10,7 +10,6 @@ import java.util.Stack;
 
 import liqp.LValue;
 import liqp.TemplateContext;
-import liqp.exceptions.ExceededMaxIterationsException;
 import liqp.nodes.AtomNode;
 import liqp.nodes.BlockNode;
 import liqp.nodes.LNode;
@@ -88,7 +87,7 @@ class For extends Tag {
         int limit = attributes.get(LIMIT);
 
         if (data instanceof Inspectable) {
-            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, (Inspectable) data);
+            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, data);
             data = evaluated.toLiquid();
         }
         if (data instanceof Map) {

--- a/src/main/resources/META-INF/services/liqp.spi.TypesSupport
+++ b/src/main/resources/META-INF/services/liqp.spi.TypesSupport
@@ -1,0 +1,2 @@
+liqp.spi.Java7DateTypesSupport
+liqp.spi.Java8DateTypesSupport

--- a/src/test/java/liqp/LValueTest.java
+++ b/src/test/java/liqp/LValueTest.java
@@ -1,0 +1,15 @@
+package liqp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import liqp.filters.Date;
+import liqp.spi.SPIHelper;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+public class LValueTest {
+    @Test
+    public void testIsTemporal() {
+        // sorry for side effect, but this is a way the java plugin system works
+        assertTrue(LValue.isTemporal(new java.util.Date(0l)));
+    }
+}

--- a/src/test/java/liqp/ProtectionSettingsTest.java
+++ b/src/test/java/liqp/ProtectionSettingsTest.java
@@ -16,7 +16,7 @@ public class ProtectionSettingsTest {
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxRenderTimeMillis() {
-        Template.parse("{% for i in (1..10000) %}{{ i }}{% endfor %}")
+        Template.parse("{% for i in (1..100000) %}{{ i }}{% endfor %}")
                 .withProtectionSettings(new ProtectionSettings.Builder().withMaxRenderTimeMillis(1).build())
                 .render();
     }

--- a/src/test/java/liqp/ReadmeSamplesTest.java
+++ b/src/test/java/liqp/ReadmeSamplesTest.java
@@ -1,0 +1,52 @@
+package liqp;
+
+import liqp.parser.Inspectable;
+import liqp.parser.LiquidSupport;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReadmeSamplesTest {
+    @Test
+    public void testInspectable() {
+        class MyParams implements Inspectable {
+            public String name = "tobi";
+        };
+        Template template = Template.parse("hi {{name}}");
+        String rendered = template.render(new MyParams());
+        assertEquals("hi tobi", rendered);
+    }
+    
+    @Test
+    public void testLiquidSupport() {
+        class MyLazy implements LiquidSupport {
+            @Override
+            public Map<String, Object> toLiquid() {
+                return Collections.singletonMap("name", "tobi");
+            }
+        };
+        Template template = Template.parse("hi {{name}}");
+        String rendered = template.render(new MyLazy());
+        assertEquals("hi tobi", rendered);
+    }
+    
+    @Test
+    public void testEagerMode() {
+        RenderSettings renderSettings = new RenderSettings.Builder()
+                .withEvaluateMode(RenderSettings.EvaluateMode.EAGER)
+                .build();
+
+        Map<String, Object> in = Collections.singletonMap("a", new Object() {
+            public String val = "tobi";
+        });
+
+        String res = Template.parse("hi {{a.val}}")
+                .withRenderSettings(renderSettings)
+                .render(in);
+        assertEquals("hi tobi", res);
+//        System.out.println(res);
+    }
+}

--- a/src/test/java/liqp/TemplateTest.java
+++ b/src/test/java/liqp/TemplateTest.java
@@ -2,13 +2,20 @@ package liqp;
 
 import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -16,6 +23,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class TemplateTest {
+
+    public static class ComparableBase implements Comparable<ComparableBase> {
+        public final int val;
+
+        public ComparableBase(int val) {
+            this.val = val;
+        }
+
+        @Override
+        public int compareTo(ComparableBase o) {
+            return Integer.compare(val, o.val);
+        }
+    }
 
     static class Foo implements Inspectable {
 
@@ -127,4 +147,98 @@ public class TemplateTest {
         // then
         assertEquals("321", res);
     }
+
+    static class SampleDateInspectable implements Inspectable {
+        public Date val;
+        public SampleDateInspectable(Date date) {
+            val = date;
+        }
+    }
+
+    @Test
+    public void testRenderInspectableDateType() {
+        // given
+        Template template = Template.parse("{{ val | date: '%e %b, %Y' }}");
+
+        // legacy API: year should be 1900 + year, month is 0-based
+        SampleDateInspectable sample = new SampleDateInspectable(new Date(120, Calendar.DECEMBER, 31));
+
+        // when
+        String res = template.render(sample);
+
+        // then
+        assertEquals("31 Dec, 2020", res);
+    }
+
+    @Test
+    public void testRenderDateType() {
+        // given
+        Template template = Template.parse("{{ val | date: '%e %b, %Y' }}");
+
+        Map<String, Object> sample = new HashMap<>();
+        // legacy API: year should be 1900 + year, month is 0-based
+        sample.put("val", new Date(120, Calendar.DECEMBER, 31));
+
+        // when
+        String res = template.render(sample);
+
+        // then
+        assertEquals("31 Dec, 2020", res);
+    }
+
+    @Test
+    public void testDeepData() {
+        // given
+        Map<String, Object> data = getDeepData();
+        Template template = Template.parse("{{a.b[2].d[3].e}}").withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).withRaiseExceptionsInStrictMode(true).build());
+
+        // when
+        String rendered = template.render(data);
+
+        // then
+        assertEquals("ok", rendered);
+    }
+
+    @Test
+    public void testDeepInspectable() {
+
+        // given
+        Inspectable data = new Inspectable() {
+            public Inspectable a = new Inspectable() {
+                public Object[] b = new Object[]{null, null, new Inspectable() {
+                    public List d = new ArrayList();
+                    {
+                        d.add(new Object()); // 0
+                        d.add(new Object()); // 1
+                        d.add(new Object()); // 2
+                        d.add(new HashMap() {{
+                            put("e", ZonedDateTime.of(LocalDateTime.of(2021, 11, 3, 16, 40, 44), ZoneId.of("America/Los_Angeles")));
+                        }
+                        }); // 3
+                    }
+                }};
+            };
+        };
+        Template template = Template.parse("{{ a.b[2].d[3].e | date: '%Y-%m-%d %H:%M:%S %Z' }}").withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).withRaiseExceptionsInStrictMode(true).build());
+
+        // when
+        String rendered = template.render(data);
+
+        // then
+        assertEquals("2021-11-03 16:40:44 Pacific Daylight Time", rendered);
+    }
+
+    private Map<String, Object> getDeepData() {
+        Map<String, Object> data = new HashMap<>();
+        Map secondIndex = Collections.singletonMap("e", "ok");
+        Object[] d = new Object[]{null, null, null, secondIndex};
+        List<Object> firstIndex = new ArrayList<>();
+        firstIndex.add(new Object()); // 0
+        firstIndex.add(new Object()); // 1
+        firstIndex.add(Collections.singletonMap("d", d)); // 2
+        Map<String, Object> a = Collections.singletonMap("b", firstIndex);
+        data.put("a", a);
+        return data;
+    }
+
 }

--- a/src/test/java/liqp/filters/AbsTest.java
+++ b/src/test/java/liqp/filters/AbsTest.java
@@ -1,11 +1,16 @@
 package liqp.filters;
 
+import liqp.RenderSettings;
 import liqp.Template;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class AbsTest {
 
@@ -36,7 +41,8 @@ public class AbsTest {
                 {"{{ 17.42 | abs }}", "17.42"},
                 {"{{ -17.42 | abs }}", "17.42"},
                 {"{{ '17.42' | abs }}", "17.42"},
-                {"{{ '-17.42' | abs }}", "17.42"}
+                {"{{ '-17.42' | abs }}", "17.42"},
+                {"{{  '0.2' | plus: '0.1' | abs }}", "0.3"}
         };
 
         for (String[] test : tests) {
@@ -46,5 +52,20 @@ public class AbsTest {
 
             assertThat(rendered, is(test[1]));
         }
+    }
+
+    @Test
+    public void ensureDateTypeIsZero() {
+        String res = Template.parse("{{ a | abs }}").render(Collections.singletonMap("a", LocalDateTime.now()));
+        assertEquals("0", res);
+
+        RenderSettings eager = new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build();
+        res = Template.parse("{{ a | abs }}").withRenderSettings(eager).render(Collections.singletonMap("a", LocalDateTime.now()));
+        assertEquals("0", res);
+    }
+
+    @Test
+    public void testMathPrecise() {
+
     }
 }

--- a/src/test/java/liqp/filters/AppendTest.java
+++ b/src/test/java/liqp/filters/AppendTest.java
@@ -1,11 +1,19 @@
 package liqp.filters;
 
+import liqp.RenderSettings;
 import liqp.Template;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class AppendTest {
 
@@ -43,5 +51,37 @@ public class AppendTest {
 
         assertThat(Template.parse("{{ a | append: 'd'}}").render(assigns), is("bcd"));
         assertThat(Template.parse("{{ a | append: b}}").render(assigns), is("bcd"));
+    }
+
+
+    // 2007-11-01 15:25:00 +0900
+    private final ZonedDateTime t = ZonedDateTime.of(
+            LocalDateTime.of(2007, 11, 1, 15, 25, 0)
+            , ZoneId.of("+09:00"));
+
+    @Test
+    public void testAppendToDateType() {
+
+        // after time
+        Map<String, Object> data = Collections.singletonMap("a", t);
+        String res = Template.parse("{{ a | append: '!' }}").render(data);
+        assertEquals("2007-11-01 15:25:00 +0900!", res);
+
+        // before time
+        res = Template.parse("{{ '!' | append: a }}").render(data);
+        assertEquals("!2007-11-01 15:25:00 +0900", res);
+
+    }
+
+    @Test
+    public void testAppendToDateTypeEager() {
+        RenderSettings eager = new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build();
+        Map<String, Object> data = Collections.singletonMap("a", t);
+
+        String res = Template.parse("{{ '!' | append: a }}").withRenderSettings(eager).render(data);
+        assertEquals("!2007-11-01 15:25:00 +0900", res);
+
+        res = Template.parse("{{ a | append: '!' }}").withRenderSettings(eager).render(data);
+        assertEquals("2007-11-01 15:25:00 +0900!", res);
     }
 }

--- a/src/test/java/liqp/filters/MinusTest.java
+++ b/src/test/java/liqp/filters/MinusTest.java
@@ -4,8 +4,11 @@ import liqp.Template;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MinusTest {
 
@@ -18,6 +21,7 @@ public class MinusTest {
                 {"{{ 8 | minus: 3. }}", "5.0"},
                 {"{{ 8 | minus: 3.0 }}", "5.0"},
                 {"{{ 8 | minus: 2.0 }}", "6.0"},
+                {"{{ '0.3' | minus: 0.1}}", "0.2"}
         };
 
         for (String[] test : tests) {
@@ -128,5 +132,10 @@ public class MinusTest {
         assertThat(Template.parse("{{ \" 5 \" | minus: 2 }}").render(), is((Object)"3"));
         assertThat(Template.parse("{{ \"5\" | minus: \"  2     \" }}").render(), is((Object)"3"));
         assertThat(Template.parse("{{ \"  5\" | minus: \"   2.0\" }}").render(), is((Object)"3.0"));
+    }
+
+    @Test
+    public void testMinusDate() {
+        assertThat(Template.parse("{{ a | minus: 1 }}").render(Collections.singletonMap("a", LocalDateTime.now())), is((Object)"-1"));
     }
 }

--- a/src/test/java/liqp/filters/ModuloTest.java
+++ b/src/test/java/liqp/filters/ModuloTest.java
@@ -50,4 +50,9 @@ public class ModuloTest {
 
         assertThat(Template.parse("{{ 3 | modulo:2 }}").render(), is((Object)"1"));
     }
+
+    @Test
+    public void testModuloWithFloated() {
+        assertThat(Template.parse("{{ 183.357 | modulo: 12 }}").render(), is((Object)"3.357"));
+    }
 }

--- a/src/test/java/liqp/filters/SizeTest.java
+++ b/src/test/java/liqp/filters/SizeTest.java
@@ -1,11 +1,16 @@
 package liqp.filters;
 
 import liqp.Template;
+import liqp.TemplateContext;
+import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SizeTest {
 
@@ -33,19 +38,28 @@ public class SizeTest {
     }
 
 	/*
-	 * def test_size
+     * def test_size
      *   assert_equal 3, @filters.size([1,2,3])
      *   assert_equal 0, @filters.size([])
      *   assert_equal 0, @filters.size(nil)
      * end
-	 */
-	@Test
-	public void applyOriginalTest() {
+     */
+    @Test
+    public void applyOriginalTest() {
 
         final Filter filter = Filter.getFilter("size");
+        TemplateContext context = new TemplateContext();
 
-        assertThat(filter.apply(new Integer[]{1, 2, 3}), is((Object) 3));
-        assertThat(filter.apply(new Object[0]), is((Object)0));
-        assertThat(filter.apply(null), is((Object)0));
-	}
+        assertThat(filter.apply(new Integer[]{1, 2, 3}, context), is( 3));
+        assertThat(filter.apply(new Object[0], context), is(0));
+        assertThat(filter.apply(null, context), is(0));
+        assertThat(filter.apply(new HashMap<>(), context), is(0));
+        assertThat(filter.apply(Collections.singletonMap("a", 1), context), is(1));
+        assertThat(filter.apply(new Inspectable() {
+            public final String a = "a";
+            public final String b = "b";
+            public final String c = "c";
+            public final String d = "d";
+        }, context), is(4));
+    }
 }

--- a/src/test/java/liqp/filters/TimesTest.java
+++ b/src/test/java/liqp/filters/TimesTest.java
@@ -5,6 +5,7 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -20,6 +21,7 @@ public class TimesTest {
                 {"{{ 8 | times: '3.0' }}", "24.0"},
                 {"{{ 8 | times: 2.0 }}", "16.0"},
                 {"{{ foo | times: 4 }}", "0"},
+                {"{{ '0.1' | times: 3 }}", "0.3"},
         };
 
         for (String[] test : tests) {
@@ -45,11 +47,12 @@ public class TimesTest {
      * def test_times
      *   assert_template_result "12", "{{ 3 | times:4 }}"
      *   assert_template_result "0", "{{ 'foo' | times:4 }}"
-     *
-     *   # Ruby v1.9.2-rc1, or higher, backwards compatible Float test
-     *   assert_match(/(6\.3)|(6\.(0{13})1)/, Template.parse("{{ '2.1' | times:3 }}").render)
-     *
      *   assert_template_result "6", "{{ '2.1' | times:3 | replace: '.','-' | plus:0}}"
+     *   assert_template_result "7.25", "{{ 0.0725 | times:100 }}"
+     *   assert_template_result "-7.25", '{{ "-0.0725" | times:100 }}'
+     *   assert_template_result "7.25", '{{ "-0.0725" | times: -100 }}'
+     * ???
+     *   assert_template_result "4", "{{ price | times:2 }}", 'price' => NumberLikeThing.new(2)
      * end
      */
     @Test
@@ -59,6 +62,9 @@ public class TimesTest {
 
         assertThat(filter.apply(3L, 4L), is((Object)12L));
         // assert_template_result "0", "{{ 'foo' | times:4 }}" // see: applyTest()
-        assertTrue(String.valueOf(filter.apply(2.1, 3L)).matches("6[.,]30{10,}1"));
+        assertTrue(String.valueOf(filter.apply(2.1, 3L)).matches("6[.,]3"));
+        assertEquals("7.25", filter.apply(0.0725, 100));
+        assertEquals("-7.25", filter.apply(-0.0725, 100));
+        assertEquals("7.25", filter.apply(-0.0725, -100));
     }
 }

--- a/src/test/java/liqp/filters/where/LiquidWhereImplTest.java
+++ b/src/test/java/liqp/filters/where/LiquidWhereImplTest.java
@@ -1,21 +1,24 @@
 package liqp.filters.where;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import liqp.ParseSettings;
 import liqp.Template;
 import liqp.parser.Flavor;
-import liqp.parser.Inspectable;
 import liqp.parser.LiquidSupport;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class LiquidWhereImplTest {
 
@@ -282,4 +285,27 @@ public class LiquidWhereImplTest {
         assertEquals("good2! ", rendered);
     }
 
+
+    @Test
+    public void testWhereWhenDateTypes() {
+        ZonedDateTime t = ZonedDateTime.of(
+                LocalDateTime.of(2007, 11, 1, 15, 25, 0)
+                , ZoneId.of("+09:00"));
+        Map<String, Object> data = new HashMap<>();
+        data.put("a", Collections.singletonList(Collections.singletonMap("time", t)));
+        data.put("b", t);
+        String template = "where in liquid respect only object equality : {{ a | where: 'time', b | map: 'time'}}";
+        String res = parse(template).render(data);
+        assertEquals("where in liquid respect only object equality : 2007-11-01 15:25:00 +0900", res);
+    }
+
+    @Test
+    public void testWhereWhenDateCompatibleTypes() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("a", Collections.singletonList(Collections.singletonMap("time", new Date(591116242000L))));
+        data.put("b", new Date(591116242000L));
+        String template = "my birthday : {{ a | where: 'time', b | map: 'time' | date: '%Y-%m-%d'}}";
+        String res = parse(template).render(data);
+        assertEquals("my birthday : 1988-09-24", res);
+    }
 }

--- a/src/test/java/liqp/nodes/GtEqNodeTest.java
+++ b/src/test/java/liqp/nodes/GtEqNodeTest.java
@@ -1,11 +1,22 @@
 package liqp.nodes;
 
 import liqp.Template;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GtEqNodeTest {
 
@@ -26,7 +37,44 @@ public class GtEqNodeTest {
             Template template = Template.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
-            assertThat(rendered, is(test[1]));
+            assertThat("template: [" + test[0]+"], expected:["+test[1]+"], real: [" + rendered + "]",rendered, is(test[1]));
         }
+    }
+
+    @Test
+    public void testDateTypes() {
+        // so many ZoneOffset.systemDefault(), because
+        // broken java.util.Date cannot another way
+        Inspectable data = new Inspectable() {
+            public Date a = new Date(100 /* milliseconds */);
+            public LocalDateTime b = LocalDateTime.ofInstant(Instant.ofEpochMilli(99), ZoneOffset.systemDefault());
+            public ZonedDateTime c = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(101), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+            public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+        };
+
+        String value = Template.parse("{% if a >= a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a >= d %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+    }
+
+    @Test
+    public void testComparableTypes() {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("a", new TemplateTest.ComparableBase(10));
+        data.put("b", new TemplateTest.ComparableBase(9));
+        data.put("c", new TemplateTest.ComparableBase(11));
+
+        String value = Template.parse("{% if a >= a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
     }
 }

--- a/src/test/java/liqp/nodes/GtNodeTest.java
+++ b/src/test/java/liqp/nodes/GtNodeTest.java
@@ -1,9 +1,20 @@
 package liqp.nodes;
 
 import liqp.Template;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -28,5 +39,42 @@ public class GtNodeTest {
 
             assertThat(rendered, is(test[1]));
         }
+    }
+
+    @Test
+    public void testDateTypes() {
+        // so many ZoneOffset.systemDefault(), because
+        // broken java.util.Date cannot another way
+        Inspectable data = new Inspectable() {
+            public Date a = new Date(100 /* milliseconds */);
+            public LocalDateTime b = LocalDateTime.ofInstant(Instant.ofEpochMilli(99), ZoneOffset.systemDefault());
+            public ZonedDateTime c = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(101), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+            public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+        };
+
+        String value = Template.parse("{% if a > a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a > b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a > c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a > d %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+    }
+
+    @Test
+    public void testComparableTypes() {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("a", new TemplateTest.ComparableBase(10));
+        data.put("b", new TemplateTest.ComparableBase(9));
+        data.put("c", new TemplateTest.ComparableBase(11));
+
+        String value = Template.parse("{% if a > a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
     }
 }

--- a/src/test/java/liqp/nodes/LtEqNodeTest.java
+++ b/src/test/java/liqp/nodes/LtEqNodeTest.java
@@ -1,11 +1,25 @@
 package liqp.nodes;
 
 import liqp.Template;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import javax.lang.model.type.NullType;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class LtEqNodeTest {
 
@@ -28,5 +42,42 @@ public class LtEqNodeTest {
 
             assertThat(rendered, is(test[1]));
         }
+    }
+
+    @Test
+    public void testDateTypes() {
+        // so many ZoneOffset.systemDefault(), because
+        // broken java.util.Date cannot another way
+        Inspectable data = new Inspectable() {
+            public Date a = new Date(100 /* milliseconds */);
+            public LocalDateTime b = LocalDateTime.ofInstant(Instant.ofEpochMilli(99), ZoneOffset.systemDefault());
+            public ZonedDateTime c = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(101), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+            public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+        };
+
+        String value = Template.parse("{% if a <= a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a <= b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a <= c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a <= d %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+    }
+
+    @Test
+    public void testComparableTypes() {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("a", new TemplateTest.ComparableBase(10));
+        data.put("b", new TemplateTest.ComparableBase(9));
+        data.put("c", new TemplateTest.ComparableBase(11));
+
+        String value = Template.parse("{% if a <= a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a <= b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a <= c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
     }
 }

--- a/src/test/java/liqp/nodes/LtNodeTest.java
+++ b/src/test/java/liqp/nodes/LtNodeTest.java
@@ -1,9 +1,20 @@
 package liqp.nodes;
 
 import liqp.Template;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -28,5 +39,41 @@ public class LtNodeTest {
 
             assertThat(rendered, is(test[1]));
         }
+    }
+
+    @Test
+    public void testDateTypes() {
+        // so many ZoneOffset.systemDefault(), because
+        // broken java.util.Date cannot another way
+        Inspectable data = new Inspectable() {
+            public Date a = new Date(100 /* milliseconds */);
+            public LocalDateTime b = LocalDateTime.ofInstant(Instant.ofEpochMilli(99), ZoneOffset.systemDefault());
+            public ZonedDateTime c = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(101), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+            public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
+        };
+
+        String value = Template.parse("{% if a < a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a < b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a < c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
+        value = Template.parse("{% if a < d %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+    }
+    @Test
+    public void testComparableTypes() {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("a", new TemplateTest.ComparableBase(10));
+        data.put("b", new TemplateTest.ComparableBase(9));
+        data.put("c", new TemplateTest.ComparableBase(11));
+
+        String value = Template.parse("{% if a < a %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a < b %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("no", value);
+        value = Template.parse("{% if a < c %}yes{% else %}no{% endif %}").render(data);
+        assertEquals("yes", value);
     }
 }

--- a/src/test/java/liqp/nodes/OutputNodeTest.java
+++ b/src/test/java/liqp/nodes/OutputNodeTest.java
@@ -4,8 +4,12 @@ import liqp.Template;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OutputNodeTest {
 
@@ -82,7 +86,8 @@ public class OutputNodeTest {
                 {"false", "false"},
                 {"nil", ""},
                 {"null", ""},
-                // {"empty", "Object"},
+                {"empty", ""},
+                {"blank", ""},
         };
 
         for (String[] keyword : keywords) {
@@ -93,7 +98,20 @@ public class OutputNodeTest {
             Template template = Template.parse(test);
             String rendered = template.render(json);
 
-            assertThat(rendered, is(expected));
+            String message = test + " --> [" + rendered + "] = [" + expected + "]";
+            assertThat(message, rendered, is(expected));
         }
     }
+
+    @Test
+    public void testDateWithFilter() {
+        // given
+
+        // when
+        String res = Template.parse("{{ a | truncate: 13 }}").render(Collections.singletonMap("a", LocalDateTime.parse("2011-12-03T10:15:30")));
+
+        // then
+        assertEquals("2011-12-03...", res);
+    }
+
 }

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -9,9 +9,7 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.ThrowableCauseMatcher;
 import org.junit.rules.ExpectedException;
-import org.hamcrest.Matcher;
 
 import java.io.File;
 import java.io.IOException;
@@ -339,7 +337,7 @@ public class IncludeTest {
         String templateText = "{% assign var = 'variable' %}{% include 'include_read_var' %}";
 
         Template template = Template.parse(templateText, liquid())
-                .withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE);
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
 
         assertEquals("variable", template.render());
 
@@ -352,7 +350,7 @@ public class IncludeTest {
         String templateText = "{% include 'include_create_new_var' %}{{ incl_var }}";
 
         Template template = Template.parse(templateText, liquid())
-                .withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE);
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
 
         assertEquals("incl_var", template.render());
     }
@@ -364,7 +362,7 @@ public class IncludeTest {
         String templateText = "{% assign var = 4 %}{% include 'include_decrement_var_not_interfere' %} ! {{ var }}";
 
         Template template = Template.parse(templateText, liquid())
-                .withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE);
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
 
         assertEquals("-1 ! 4", template.render());
     }
@@ -377,7 +375,7 @@ public class IncludeTest {
         Template template = Template.parse("" +
                 "{% assign var = 'variable' %}" +
                 "{% include include_read_var.liquid %}", jekyll())
-                .withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE);
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
 
         assertEquals("variable", template.render());
 
@@ -395,7 +393,7 @@ public class IncludeTest {
                 +     "{% assign inner = n %}"
                 +     "{% include include_iterations_variables.liquid %}"
                 + "{% endfor %}", jekyll())
-                .withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE)
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build())
                 .render();
 
 
@@ -426,7 +424,7 @@ public class IncludeTest {
                 + "[{% include 'include_decrement_var' %}]"
                 + "[{% decrement var1 %},{% increment var2 %}]"
                 + "[{{ var1 }}, {{ var2 }}]"
-                + "").withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE)
+                + "").withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build())
                 .render();
 
         assertEquals("[-1,0][-2,1][-3,2][-3, 3]", rendered);
@@ -440,7 +438,7 @@ public class IncludeTest {
                 + "{% cycle 1,2,3,4 %}"
                 + "{% include 'include_cycle' %}"
                 + "")
-                .withRenderSettings(RenderSettings.EXCEPTIONS_FROM_INCLUDE)
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build())
                 .render();
         assertEquals("1234", rendered);
     }


### PR DESCRIPTION
Changes:
* java support moved from 1.7 to 1.8. Sorry.
* because of incompatible changes, the library version now is 0.8.x
* documentation upgrade to reflect most important changes
* time-related changes:
  * for propper support java8 datetime types by the jackson the `jackson-datatype-jsr310 dependency` added 
  * `strftime` formatter rewritten from scratch and moved to own library(`ua.co.k:strftime4j:1.0.3`), so can be upgradable independently via maven
  * datetime types now printed in the output with the same format as it would be in ruby, so it's +1 for compatibility
  * the template now can have default `locale` so the formatting of some variables will be locale-specific(most obvious place - timezone names and month names in different languages)
  * the template now can have default `timezone`, so in all place when the timezone was printed but not provided - the default one will be used  
  * java [built-in plugin system ](https://www.oracle.com/technical-resources/articles/javase/extensible.html) is used for supporting different time libraries (like [joda-time](https://www.joda.org/joda-time/) or [ThreeTen](https://www.threeten.org/)). See example for java7 types in `Java7DateTypesSupport` class.
  * date filter now handle dates with 'T' part, fix this: https://github.com/bkiers/Liqp/issues/171
 * other minor changes:
   * `Abs`, `Minus`, `Plus`, `Modulo` and `Times` filters fixed behavior with handling numbers with decimal points(now uses the same number format as ruby's `float` type)
   * `Abs` filter fixed behavior when input is not a number (was - return input, propper - return `0`)
   * `Size` filer now can count the size of objects (key-value pairs)
   * fix `empty` and `blank` objects/keywords rendering - now as empty line(before - it was as "Object@2a139a55")
   * the expressions with `>`, `<`, `>=` and `<=` now handle `Comparable` objects if they can be compared.
   * in case of error of accessing object by square brackets the error now show real error expression, like `a[b]` instead of `a[null]`
