### PR TITLE
Optimize the parsing of large templates

### DIFF
--- a/src/main/java/liqp/Examples.java
+++ b/src/main/java/liqp/Examples.java
@@ -1,8 +1,10 @@
 package liqp;
 
-import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import liqp.filters.Filter;
 import liqp.nodes.LNode;
+import liqp.tags.Block;
 import liqp.tags.Tag;
 import java.util.HashMap;
 import java.util.Map;
@@ -119,7 +121,7 @@ public class Examples {
 
     private static void customLoopTag() {
 
-        Tag.registerTag(new Tag("loop"){
+        Tag.registerTag(new Block("loop"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
 
@@ -146,10 +148,9 @@ public class Examples {
     }
 
     public static void instanceTag() {
-
         String source = "{% loop 5 %}looping!\n{% endloop %}";
-
-        Template template = Template.parse(source).with(new Tag("loop"){
+        List<Tag> tags = new ArrayList<>();
+        tags.add(new Block("loop"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
 
@@ -166,6 +167,8 @@ public class Examples {
             }
         });
 
+        Template template = Template.parse(source, tags, new ArrayList<Filter>());
+
         String rendered = template.render();
 
         System.out.println(rendered);
@@ -173,7 +176,8 @@ public class Examples {
 
     public static void instanceFilter() {
 
-        Template template = Template.parse("{{ numbers | sum }}").with(new Filter("sum"){
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new Filter("sum"){
             @Override
             public Object apply(Object value, TemplateContext context, Object... params) {
 
@@ -188,6 +192,8 @@ public class Examples {
                 return sum;
             }
         });
+
+        Template template = Template.parse("{{ numbers | sum }}", new ArrayList<Tag>(), filters);
 
         String rendered = template.render("{\"numbers\" : [1, 2, 3, 4, 5]}");
         System.out.println(rendered);

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -40,6 +40,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
       throw new IllegalArgumentException("parseSettings == null");
 
     this.tags = tags;
+
     this.filters = filters;
     this.parseSettings = parseSettings;
   }
@@ -90,6 +91,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
   //  ;
   @Override
   public LNode visitOther_tag(Other_tagContext ctx) {
+    String blockId = ctx.BlockId().getText();
 
     List<LNode> expressions = new ArrayList<LNode>();
 
@@ -97,31 +99,32 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
       expressions.add(new AtomNode(ctx.other_tag_parameters().getText()));
     }
 
-    if (ctx.other_tag_block() != null) {
-      expressions.add(visitOther_tag_block(ctx.other_tag_block()));
-    }
-
-    Tag tag = tags.get(ctx.Id().getText());
-    if (tag == null) {
-      throw new RuntimeException("The tag '" + ctx.Id().getText() + "' is not registered.");
-    }
-
-    return new TagNode(tag, expressions.toArray(new LNode[expressions.size()]));
-  }
-
-  // custom_tag_block
-  //  : atom+? tagStart EndId TagEnd
-  //  ;
-  @Override
-  public BlockNode visitOther_tag_block(Other_tag_blockContext ctx) {
-
     BlockNode node = new BlockNode(isRootBlock);
 
     for (AtomContext child : ctx.atom()) {
       node.add(visit(child));
     }
 
-    return node;
+    Tag tag = tags.get(blockId);
+    if (tag == null) {
+      throw new RuntimeException("The tag '" + blockId + "' is not registered.");
+    }
+
+    expressions.add(node);
+
+    return new TagNode(tag, expressions.toArray(new LNode[expressions.size()]));
+  }
+
+  @Override
+  public LNode visitSimple_tag(Simple_tagContext ctx) {
+
+    List<LNode> expressions = new ArrayList<LNode>();
+
+    if (ctx.other_tag_parameters() != null) {
+      expressions.add(new AtomNode(ctx.other_tag_parameters().getText()));
+    }
+
+    return new TagNode(tags.get(ctx.SimpleTagId().getText()), expressions.toArray(new LNode[expressions.size()]));
   }
 
   // raw_tag

--- a/src/main/java/liqp/tags/Block.java
+++ b/src/main/java/liqp/tags/Block.java
@@ -1,0 +1,21 @@
+package liqp.tags;
+
+public abstract class Block extends Tag {
+    /**
+     * Used for all package protected blocks in the liqp.tags-package
+     * whose name is their class name lower cased.
+     */
+    protected Block() {
+        super();
+    }
+
+    /**
+     * Creates a new instance of a Block.
+     *
+     * @param name
+     *         the name of the block.
+     */
+    public Block(String name) {
+        super(name);
+    }
+}

--- a/src/main/java/liqp/tags/Capture.java
+++ b/src/main/java/liqp/tags/Capture.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Capture extends Tag {
+class Capture extends Block {
 
     /*
      * Block tag that captures text into a variable

--- a/src/main/java/liqp/tags/Case.java
+++ b/src/main/java/liqp/tags/Case.java
@@ -5,7 +5,7 @@ import liqp.TemplateContext;
 import liqp.nodes.BlockNode;
 import liqp.nodes.LNode;
 
-class Case extends Tag {
+class Case extends Block {
 
     /*
      * Block tag, its the standard case...when block

--- a/src/main/java/liqp/tags/Comment.java
+++ b/src/main/java/liqp/tags/Comment.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Comment extends Tag {
+class Comment extends Block {
 
     /*
      * Block tag, comments out the text in the block

--- a/src/main/java/liqp/tags/Cycle.java
+++ b/src/main/java/liqp/tags/Cycle.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-class Cycle extends Tag {
+class Cycle extends Block {
 
     /*
      * Cycle is usually used within a loop to alternate

--- a/src/main/java/liqp/tags/For.java
+++ b/src/main/java/liqp/tags/For.java
@@ -23,7 +23,7 @@ import liqp.parser.LiquidSupport;
  * https://shopify.dev/docs/themes/liquid/reference/objects/for-loops
  *
  */
-class For extends Tag {
+class For extends Block {
 
     private static final String OFFSET = "offset";
     private static final String LIMIT = "limit";

--- a/src/main/java/liqp/tags/If.java
+++ b/src/main/java/liqp/tags/If.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class If extends Tag {
+class If extends Block {
 
     /*
      * Standard if/else block

--- a/src/main/java/liqp/tags/Ifchanged.java
+++ b/src/main/java/liqp/tags/Ifchanged.java
@@ -5,7 +5,7 @@ import liqp.nodes.LNode;
 
 import java.util.*;
 
-public class Ifchanged extends Tag {
+public class Ifchanged extends Block {
 
     /*
         {% for product in products %}

--- a/src/main/java/liqp/tags/Raw.java
+++ b/src/main/java/liqp/tags/Raw.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Raw extends Tag {
+class Raw extends Block {
 
     /*
      * temporarily disable tag processing to avoid syntax conflicts.

--- a/src/main/java/liqp/tags/Tablerow.java
+++ b/src/main/java/liqp/tags/Tablerow.java
@@ -8,8 +8,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-
-class Tablerow extends Tag {
+class Tablerow extends Block {
 
     private static final String COLS = "cols";
     private static final String LIMIT = "limit";

--- a/src/main/java/liqp/tags/Tag.java
+++ b/src/main/java/liqp/tags/Tag.java
@@ -61,12 +61,12 @@ public abstract class Tag extends LValue {
     }
 
     /**
-     * Retrieves a filter with a specific name.
+     * Retrieves a tag with a specific name.
      *
      * @param name
-     *         the name of the filter to retrieve.
+     *         the name of the tag to retrieve.
      *
-     * @return a filter with a specific name.
+     * @return a tag with a specific name.
      */
     public static Tag getTag(String name) {
 

--- a/src/main/java/liqp/tags/Unless.java
+++ b/src/main/java/liqp/tags/Unless.java
@@ -3,7 +3,7 @@ package liqp.tags;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
 
-class Unless extends Tag {
+class Unless extends Block {
 
     /*
      * Mirror of if statement

--- a/src/test/java/liqp/TemplateTest.java
+++ b/src/test/java/liqp/TemplateTest.java
@@ -2,6 +2,7 @@ package liqp;
 
 import liqp.nodes.LNode;
 import liqp.parser.Inspectable;
+import liqp.tags.Block;
 import liqp.tags.Tag;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
@@ -231,23 +232,11 @@ public class TemplateTest {
     }
 
     @Test
-    public void testCustomTagRegistration() {
-        Template template = Template.parse("{% custom_tag %}")
-            .with(new Tag("custom_tag") {
-                @Override
-                public Object render(TemplateContext context, LNode... nodes) {
-                    return "xxx";
-                }
-            });
-        assertEquals("xxx", template.render());
-    }
-
-    @Test
     public void testCustomTagMissingErrorReporting() {
         try {
             Template.parse("{% custom_tag %}");
         } catch (Exception e) {
-            assertEquals("The tag 'custom_tag' is not registered.", e.getMessage());
+            assertEquals("parser error \"Invalid Tag: 'custom_tag'\" on line 1, index 3", e.getMessage());
         }
     }
 

--- a/src/test/java/liqp/filters/DateTest.java
+++ b/src/test/java/liqp/filters/DateTest.java
@@ -33,6 +33,7 @@ public class DateTest {
         Filter.registerFilter(new Date());
     }
 
+    // NOTE: you have to put your machine in US/Eastern time for this test to pass
     @Test
     public void applyTest() throws RecognitionException {
 

--- a/src/test/java/liqp/nodes/BlockNodeTest.java
+++ b/src/test/java/liqp/nodes/BlockNodeTest.java
@@ -2,6 +2,7 @@ package liqp.nodes;
 
 import liqp.Template;
 import liqp.TemplateContext;
+import liqp.tags.Block;
 import liqp.tags.Tag;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class BlockNodeTest {
     @Test
     public void customTagTest() throws RecognitionException {
 
-        Tag.registerTag(new Tag("testtag"){
+        Tag.registerTag(new Block("testtag"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
                 return null;

--- a/src/test/java/liqp/parser/ParseTest.java
+++ b/src/test/java/liqp/parser/ParseTest.java
@@ -1,7 +1,11 @@
 package liqp.parser;
 
 import liqp.Template;
+import liqp.TemplateContext;
 import liqp.exceptions.LiquidException;
+import liqp.nodes.LNode;
+import liqp.tags.Block;
+import liqp.tags.Tag;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/liqp/parser/v4/LiquidParserTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidParserTest.java
@@ -1,5 +1,7 @@
 package liqp.parser.v4;
 
+import java.util.HashSet;
+import java.util.Set;
 import liquid.parser.v4.LiquidParser;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
@@ -14,6 +16,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class LiquidParserTest {
+
+    // simple error listener that captures the last error message.
+    class CapturingErrorListener extends BaseErrorListener {
+        private String lastErrorMessage = null;
+
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line,
+        int charPositionInLine, String msg, RecognitionException e) {
+            lastErrorMessage = msg;
+        }
+
+        public String getLastErrorMessage() {
+            return lastErrorMessage;
+        }
+    }
 
     // custom_tag
     //  : tagStart Id custom_tag_parameters? TagEnd custom_tag_block?
@@ -33,19 +50,84 @@ public class LiquidParserTest {
     @Test
     public void testCustom_tag() {
 
+        Set<String> emptySet = new HashSet<>();
+        Set<String> muSet = new HashSet<>();
+        muSet.add("mu");
+        muSet.add("other");
+
         assertThat(
-                texts("{% mu %}", "other_tag"),
+                texts("{% mu %}", "simple_tag", emptySet, muSet),
                 equalTo(array("{%", "mu", "%}"))
         );
 
         assertThat(
-                texts("{% mu | 42 %}", "other_tag"),
+                texts("{% mu | 42 %}", "simple_tag", emptySet, muSet),
                 equalTo(array("{%", "mu", "|42", "%}"))
         );
 
         assertThat(
-                texts("{% mu %} . {% endmu %}", "other_tag"),
-                equalTo(array("{%", "mu", "%}", " . {%endmu%}"))
+                texts("{% mu %} . {% endmu %}", "other_tag", muSet, emptySet),
+                equalTo(array("{%", "mu", "%}", " . ", "{%", "endmu", "%}"))
+        );
+
+        assertThat(
+            texts("{% mu as_df %} . {% endmu %}", "other_tag", muSet, emptySet),
+            equalTo(array("{%", "mu", "as_df", "%}", " . ", "{%", "endmu", "%}"))
+        );
+
+        CapturingErrorListener el = new CapturingErrorListener();
+        assertThat(
+            textsWithError("{% mu | 42%} . {% endbad %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "mu", "|42","%}", " . ", "{%", "endbad", "%}"))
+        );
+
+        assertThat(el.getLastErrorMessage(), equalTo("Invalid End Tag: 'endbad'"));
+
+        assertThat(
+            textsWithError("{% mu %} . {% endother %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "mu", "%}", " . ", "{%", "endother", "%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Mismatched End Tag: 'endother'"));
+
+        assertThat(
+            textsWithError("{% bad %} . {% endbad %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "bad", "%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Invalid Tag: 'bad'"));
+
+        assertThat(
+            textsWithError("{% bad parameter %} . {% endbad %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "bad", "parameter", "%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Invalid Tag: 'bad'"));
+
+        assertThat(
+            textsWithError("{% bad parameter[index] %} . {% endbad %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "bad", "parameter[index]", "%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Invalid Tag: 'bad'"));
+
+        assertThat(
+            textsWithError("{% bad parameter.index %} . {% endbad %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "bad", "parameter.index", "%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Invalid Tag: 'bad'"));
+
+        assertThat(
+            textsWithError("{% bad parameter.index.index2 %} . {% endbad %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "bad", "parameter.index.index2", "%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Invalid Tag: 'bad'"));
+
+        assertThat(
+            textsWithError("{% mu %} {% mu %} {% endmu %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "mu", "%}", " ", "{%mu%} {%endmu%}"))
+        );
+        assertThat(el.getLastErrorMessage(), equalTo("Missing End Tag"));
+
+        assertThat(
+            textsWithError("{% %}", "error_other_tag", muSet, emptySet, el),
+            equalTo(array("{%", "%}"))
         );
     }
 
@@ -334,13 +416,23 @@ public class LiquidParserTest {
         );
     }
 
+    private static String[] textsWithError(String source, String ruleName, Set<String> customBlocks, Set<String> customTags, BaseErrorListener el) {
+        ParseTree tree = parseWithListener(source, ruleName, customBlocks, customTags, el, true);
+
+        return texts(tree);
+    }
+
+    private static String[] texts(String source, String ruleName, Set<String> customBlocks, Set<String> customTags) {
+        ParseTree tree = parse(source, ruleName, customBlocks, customTags);
+
+        return texts(tree);
+    }
 
     private static String[] texts(String source, String ruleName, boolean isLiquid) {
         ParseTree tree = parse(source, ruleName, isLiquid);
 
         return texts(tree);
     }
-
 
     private static String[] texts(String source, String ruleName) {
         return texts(source, ruleName, true);
@@ -358,15 +450,14 @@ public class LiquidParserTest {
     }
 
     private static ParseTree parse(String source, String ruleName, boolean isLiquid) {
+        return parse(source, ruleName, new HashSet<String>(), new HashSet<String>(), isLiquid);
+    }
 
-        LiquidParser parser = new LiquidParser(LiquidLexerTest.commonTokenStream(source, false), isLiquid);
+    private static ParseTree parseWithListener(String source, String ruleName, Set<String> customBlocks, Set<String> customTags, BaseErrorListener el, Boolean isLiquid) {
+        LiquidParser parser = new LiquidParser(LiquidLexerTest.commonTokenStream(source, false, customBlocks, customTags), isLiquid);
 
-        parser.addErrorListener(new BaseErrorListener(){
-            @Override
-            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        parser.removeErrorListeners();
+        parser.addErrorListener(el);
 
         try {
             Method method = parser.getClass().getMethod(ruleName);
@@ -375,6 +466,20 @@ public class LiquidParserTest {
         catch (Exception e) {
             throw new RuntimeException("could not parse source '" + source + "' using rule: " + ruleName);
         }
+    }
+
+    private static ParseTree parse(String source, String ruleName, Set<String> customBlocks, Set<String> customTags) {
+        return parse(source, ruleName, customBlocks, customTags, true);
+    }
+
+    private static ParseTree parse(String source, String ruleName, Set<String> customBlocks, Set<String> customTags, Boolean isLiquid) {
+        BaseErrorListener el = new BaseErrorListener(){
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        return parseWithListener(source, ruleName, customBlocks, customTags, el, isLiquid);
     }
 
     private static String[] array(String... values) {

--- a/src/test/java/liqp/tags/TagTest.java
+++ b/src/test/java/liqp/tags/TagTest.java
@@ -10,10 +10,30 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class TagTest {
+    @Test
+    public void testNestedCustomTagsAndBlocks() {
+        Tag.registerTag(new Block("block") {
+            @Override
+            public Object render(TemplateContext context, LNode... nodes) {
+                String data = (nodes.length >= 2 ? nodes[1].render(context) : nodes[0].render(context)).toString();
+
+                return "blk[" + data + "]";
+            }
+        });
+
+        Tag.registerTag(new Tag("simple") {
+            @Override
+            public Object render(TemplateContext context, LNode... nodes) {
+                return "(sim)";
+            }
+        });
+        String templateString = "{% block %}a{% simple %}b{% block %}c{% endblock %}d{% endblock %}";
+        Template template = Template.parse(templateString);
+        assertThat("blk[a(sim)bblk[c]d]", is(template.render()));
+    }
 
     @Test
     public void testCustomTag() throws RecognitionException {
-
         Tag.registerTag(new Tag("twice") {
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
@@ -31,7 +51,7 @@ public class TagTest {
     @Test
     public void testCustomTagBlock() throws RecognitionException {
 
-        Tag.registerTag(new Tag("twice") {
+        Tag.registerTag(new Block("twice") {
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
                 LNode blockNode = nodes[nodes.length - 1];


### PR DESCRIPTION
We were getting performance issues for large templates with nested
custom tags and blocks.

In particular, items of the form:
```
{% block data %}
    {% simple data %}

    <large string>
{% endblock %}
```
Would parse a lot slower in liqp than shopify's ruby implementation,
roughly linearly with the size of the string addendum.

We've noticed that the SLL parser is blazing fast, but liqp falls back
to the LL parser a lot.

A case like
```
    {% block %}
      {% simple %}
    {% endblock %}
```
will use the LL parser because there isn't a matching end for `simple`,
whereas this works:
```
   {% block %}
      {% simple %}{% endsimple %}
    {% endblock %}
```

We augment the parser to work more dynamically -- with more information
about the starts/ends of tags and blocks, we can invoke the SLL parser, leading to
dramatic performance improvements.

Note that Liqp@HEAD does not differentiate between tags and blocks.

This PR significantly changes the API, since we now differentiate between
blocks and tags. However, since the tags and blocks are now passed to
the lexer for an optimized parser (SLL), we believe the changes are
worth it.

Also added some error handling for mismatched tags and broken templates.
Removed a few edges around open ({{) and close (}}) tags.

Closes #170.