### PR TITLE
Slice filter: Fix "Potential null pointer access" error

### DIFF
--- a/src/main/java/liqp/filters/Slice.java
+++ b/src/main/java/liqp/filters/Slice.java
@@ -52,7 +52,7 @@ public class Slice extends Filter {
         }
 
         return array == null ?
-                string.substring(offset, offset + length) :
+                string == null ? "" : string.substring(offset, offset + length) :
                 Arrays.copyOfRange(array, offset, offset + length);
     }
 }


### PR DESCRIPTION
Eclipse complains about this. Probably a false positive but it is marked as an error.

Check for null string and return an empty one instead.