### PR TITLE
Refactor Template parser to TemplateParser; fix global scope issue

### DIFF
--- a/src/main/java/liqp/Insertions.java
+++ b/src/main/java/liqp/Insertions.java
@@ -1,0 +1,206 @@
+package liqp;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import liqp.blocks.Block;
+import liqp.blocks.Capture;
+import liqp.blocks.Case;
+import liqp.blocks.Comment;
+import liqp.blocks.Cycle;
+import liqp.blocks.For;
+import liqp.blocks.If;
+import liqp.blocks.Ifchanged;
+import liqp.blocks.Raw;
+import liqp.blocks.Tablerow;
+import liqp.blocks.Unless;
+import liqp.filters.Filters;
+import liqp.tags.Assign;
+import liqp.tags.Break;
+import liqp.tags.Continue;
+import liqp.tags.Decrement;
+import liqp.tags.Include;
+import liqp.tags.Increment;
+
+/**
+ * An immutable map of {@link Insertion}s.
+ * 
+ * @author Christian Kohlschütter
+ */
+public final class Insertions {
+    private final Map<String, Insertion> map;
+
+    private final Set<String> blockNames;
+    private final Set<String> tagNames;
+
+    public static final Insertions EMPTY = new Insertions(Collections.emptyMap());
+
+    /**
+     * The standard insertions.
+     */
+    public static final Insertions STANDARD_INSERTIONS = Insertions.of( //
+            new Assign(), //
+            new Break(), //
+            new Capture(), //
+            new Case(), //
+            new Comment(), //
+            new Continue(), //
+            new Cycle(), //
+            new Decrement(), //
+            new For(), //
+            new If(), //
+            new Ifchanged(), //
+            new Include(), //
+            new Increment(), //
+            new Raw(), //
+            new Tablerow(), //
+            new Unless() //
+    );
+
+    /**
+     * Creates a new {@link Insertions} instance with the given insertions.
+     * 
+     * @param insertions
+     *            The insertions to add.
+     */
+    public static Insertions of(Collection<Insertion> insertions) {
+        if (insertions.isEmpty()) {
+            return EMPTY;
+        }
+        return new Insertions(insertions.stream().collect(Collectors.toMap(Insertion::getName, Function
+                .identity())));
+    }
+
+    /**
+     * Returns an {@link Insertions} instance with the given insertions.
+     * 
+     * @param insertions
+     *            The insertions to add.
+     */
+    public static Insertions of(Insertion... insertions) {
+        return of(Arrays.asList(insertions));
+    }
+
+    /**
+     * Returns an {@link Insertions} instance with the given insertions.
+     * 
+     * @param insertions
+     *            The insertions to add.
+     */
+    public static Insertions of(Map<String, Insertion> insertions) {
+        if (insertions.isEmpty()) {
+            return EMPTY;
+        }
+
+        return new Insertions(insertions);
+    }
+
+    private Insertions(Map<String, Insertion> insertions) {
+        Objects.requireNonNull(insertions);
+
+        this.map = new HashMap<>(insertions);
+
+        this.blockNames = Collections.unmodifiableSet(getNames(en -> en.getValue() instanceof Block));
+        this.tagNames = Collections.unmodifiableSet(getNames(en -> !(en.getValue() instanceof Block)));
+    }
+
+    void writeTo(Map<String, Insertion> target) {
+        target.putAll(map);
+    }
+
+    /**
+     * Returns a new {@link Filters} instance that combines this instance with the filters of the other
+     * instance.
+     * 
+     * If there are filters with the same name in both instances, then the {@code other} filter takes
+     * precedence.
+     * 
+     * @param other
+     *            The other Filters instance.
+     * @return A new, merged instance.
+     */
+    public Insertions mergeWith(Insertions other) {
+        Objects.requireNonNull(other);
+
+        if (other == this || other.map.isEmpty()) {
+            return this;
+        } else if (this.map.isEmpty()) {
+            return other;
+        }
+
+        Map<String, Insertion> newMap = new HashMap<>(map);
+        newMap.putAll(other.map);
+        return new Insertions(newMap);
+    }
+
+    /**
+     * Returns a set of names of insertions matching the given predicate.
+     * 
+     * @param predicate
+     *            the predicate.
+     * @return The set of names.
+     */
+    private Set<String> getNames(Predicate<? super Map.Entry<String, Insertion>> predicate) {
+        return this.map.entrySet().stream().filter(predicate).map(x -> x.getKey()).collect(Collectors
+                .toSet());
+    }
+
+    Set<String> getBlockNames() {
+        return blockNames;
+    }
+
+    Set<String> getTagNames() {
+        return tagNames;
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Insertions)) {
+            return false;
+        }
+        return ((Insertions) obj).map.equals(map);
+    }
+
+    @Override
+    public String toString() {
+        if (map.isEmpty()) {
+            return getClass().getName() + ".EMPTY";
+        } else {
+            return super.toString() + map;
+        }
+    }
+
+    /**
+     * Returns the {@link Insertion} registered under the given name, or {@code null} if no such
+     * {@link Insertion} exists in this {@link Insertions} instance.
+     * 
+     * @param name
+     *            The name of the {@link Insertion}.
+     * @return The instance.
+     */
+    public Insertion get(String name) {
+        return map.get(name);
+    }
+    
+    /**
+     * Returns an unmodifiable collection of the stored {@link Insertion}s.
+     * 
+     * @return The collection.
+     */
+    public Collection<Insertion> values() {
+        return Collections.unmodifiableCollection(map.values());
+    }
+}

--- a/src/main/java/liqp/LValue.java
+++ b/src/main/java/liqp/LValue.java
@@ -162,7 +162,8 @@ public abstract class LValue {
     public static ZonedDateTime asTemporal(Object value, TemplateContext context) {
         ZonedDateTime time = ZonedDateTime.now();
         if (value instanceof TemporalAccessor) {
-            time = getZonedDateTimeFromTemporalAccessor((TemporalAccessor) value, context.renderSettings.defaultTimeZone);
+            time = getZonedDateTimeFromTemporalAccessor((TemporalAccessor) value, context
+                    .getRenderSettings().defaultTimeZone);
         } else if (CustomDateFormatRegistry.isCustomDateType(value)) {
             time = CustomDateFormatRegistry.getFromCustomType(value);
         }

--- a/src/main/java/liqp/ParseSettings.java
+++ b/src/main/java/liqp/ParseSettings.java
@@ -1,38 +1,38 @@
 package liqp;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import liqp.filters.Filter;
+import liqp.filters.Filters;
 import liqp.parser.Flavor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 public class ParseSettings {
-
-    public final static Flavor DEFAULT_FLAVOR = Flavor.LIQUID;
+    public static final Flavor DEFAULT_FLAVOR = Flavor.LIQUID;
+    public static final ParseSettings DEFAULT = DEFAULT_FLAVOR.defaultParseSettings();
 
     public final Flavor flavor;
     public final boolean stripSpacesAroundTags;
     public final boolean stripSingleLine;
     public final ObjectMapper mapper;
-    public final List<Insertion> insertions;
-    public final List<Filter> filters;
+    public final Insertions insertions;
+    public final Filters filters;
 
     public static class Builder {
-
         Flavor flavor;
         boolean stripSpacesAroundTags;
         boolean stripSingleLine;
         ObjectMapper mapper;
         List<Insertion> insertions = new ArrayList<>();
         List<Filter> filters = new ArrayList<>();
-        
 
         public Builder() {
-            this.flavor = DEFAULT_FLAVOR;
+            this.flavor = null;
             this.stripSpacesAroundTags = false;
             this.mapper = new ObjectMapper();
             mapper.registerModule(new JavaTimeModule());
@@ -51,7 +51,8 @@ public class ParseSettings {
         public Builder withStripSpaceAroundTags(boolean stripSpacesAroundTags, boolean stripSingleLine) {
 
             if (stripSingleLine && !stripSpacesAroundTags) {
-                throw new IllegalStateException("stripSpacesAroundTags must be true if stripSingleLine is true");
+                throw new IllegalStateException(
+                        "stripSpacesAroundTags must be true if stripSingleLine is true");
             }
 
             this.stripSpacesAroundTags = stripSpacesAroundTags;
@@ -63,28 +64,55 @@ public class ParseSettings {
             this.mapper = mapper;
             return this;
         }
-        
+
+        public Builder with(ParseSettings settings) {
+            return withFlavor(settings.flavor) //
+                    .withStripSpaceAroundTags(stripSpacesAroundTags, stripSingleLine) //
+                    .withMapper(settings.mapper) //
+                    .withInsertions(settings.insertions.values()) //
+                    .withFilters(settings.filters.values());
+        }
+
         public Builder with(Insertion insertion) {
             this.insertions.add(insertion);
             return this;
         }
-        
+
+        @Deprecated
+        Builder withInsertions(Collection<Insertion> insertions) {
+            this.insertions.addAll(insertions);
+            return this;
+        }
+
         public Builder with(Filter filter) {
             filters.add(filter);
             return this;
         }
 
+        @Deprecated
+        Builder withFilters(Collection<Filter> filters) {
+            this.filters.addAll(filters);
+            return this;
+        }
+
         public ParseSettings build() {
-            return new ParseSettings(this.flavor, this.stripSpacesAroundTags, this.stripSingleLine, this.mapper, this.insertions, this.filters);
+            Flavor fl = this.flavor;
+            if (fl == null) {
+                fl = Flavor.LIQUID;
+            }
+
+            return new ParseSettings(fl, this.stripSpacesAroundTags, this.stripSingleLine, this.mapper,
+                    this.insertions, this.filters);
         }
     }
 
-    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags, boolean stripSingleLine, ObjectMapper mapper, List<Insertion> insertions, List<Filter> filters) {
+    private ParseSettings(Flavor flavor, boolean stripSpacesAroundTags, boolean stripSingleLine,
+            ObjectMapper mapper, List<Insertion> insertions, List<Filter> filters) {
         this.flavor = flavor;
         this.stripSpacesAroundTags = stripSpacesAroundTags;
         this.stripSingleLine = stripSingleLine;
         this.mapper = mapper;
-        this.insertions = Collections.unmodifiableList(insertions);
-        this.filters = Collections.unmodifiableList(filters);
+        this.insertions = Insertions.of(insertions);
+        this.filters = Filters.of(filters);
     }
 }

--- a/src/main/java/liqp/ProtectionSettings.java
+++ b/src/main/java/liqp/ProtectionSettings.java
@@ -3,6 +3,7 @@ package liqp;
 import liqp.exceptions.ExceededMaxIterationsException;
 
 public class ProtectionSettings {
+    public static final ProtectionSettings DEFAULT = new ProtectionSettings.Builder().build();
 
     public final int maxIterations;
     public final int maxSizeRenderedString;

--- a/src/main/java/liqp/RenderSettings.java
+++ b/src/main/java/liqp/RenderSettings.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 public class RenderSettings {
 
     public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+    
+    public static final RenderSettings DEFAULT = new RenderSettings.Builder().build();
 
     public enum EvaluateMode {
         LAZY,

--- a/src/main/java/liqp/TemplateParser.java
+++ b/src/main/java/liqp/TemplateParser.java
@@ -1,0 +1,110 @@
+package liqp;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import liqp.parser.Flavor;
+
+/**
+ * The new main entrance point of this library.
+ */
+public class TemplateParser {
+    /**
+     * Returns a {@link TemplateParser} configured with all default settings for "Liquid" flavor.
+     */
+    public static final TemplateParser DEFAULT = Flavor.LIQUID.defaultParser();
+    public static final TemplateParser DEFAULT_JEKYLL = Flavor.JEKYLL.defaultParser();
+
+    private final ParseSettings parseSettings;
+    private final RenderSettings renderSettings;
+    private final ProtectionSettings protectionSettings;
+
+    public static class Builder {
+        private ParseSettings parseSettings = ParseSettings.DEFAULT;
+        private RenderSettings renderSettings = RenderSettings.DEFAULT;
+        private ProtectionSettings protectionSettings = ProtectionSettings.DEFAULT;
+        private boolean withLegacyMode;
+
+        public Builder() {
+        }
+
+        public Builder withParseSettings(ParseSettings s) {
+            this.parseSettings = s;
+            return this;
+        }
+
+        public Builder withRenderSettings(RenderSettings s) {
+            this.renderSettings = s;
+            return this;
+        }
+
+        public Builder withProtectionSettings(ProtectionSettings s) {
+            this.protectionSettings = s;
+            return this;
+        }
+
+        Builder withLegacyMode(boolean b) {
+            this.withLegacyMode = b;
+            return this;
+        }
+
+        public TemplateParser build() {
+            if (withLegacyMode) {
+                return new TemplateParser.LegacyMode(this.parseSettings, this.renderSettings,
+                        this.protectionSettings);
+            } else {
+                return new TemplateParser(this.parseSettings, this.renderSettings,
+                        this.protectionSettings);
+            }
+        }
+    }
+
+    TemplateParser(ParseSettings parseSettings, RenderSettings renderSettings,
+            ProtectionSettings protectionSettings) {
+        this.parseSettings = parseSettings;
+        this.renderSettings = renderSettings;
+        this.protectionSettings = protectionSettings;
+    }
+
+    public Template parse(File file) throws IOException {
+        return new Template.BuiltTemplate(this, file);
+    }
+
+    public Template parse(String input) {
+        return new Template.BuiltTemplate(this, input);
+    }
+
+    public Template parse(InputStream input) throws IOException {
+        return new Template.BuiltTemplate(this, input);
+    }
+
+    public ParseSettings getParseSettings() {
+        return parseSettings;
+    }
+
+    public RenderSettings getRenderSettings() {
+        return renderSettings;
+    }
+
+    public ProtectionSettings getProtectionSettings() {
+        return protectionSettings;
+    }
+
+    /**
+     * This is only used internally; do not use.
+     * 
+     * @return {@code true} if this parser is following old-style global settings.
+     */
+    @Deprecated
+    public boolean isLegacyMode() {
+        return (this instanceof LegacyMode);
+    }
+
+    private static class LegacyMode extends TemplateParser {
+        LegacyMode(ParseSettings parseSettings, RenderSettings renderSettings,
+                ProtectionSettings protectionSettings) {
+            super(parseSettings, renderSettings, protectionSettings);
+        }
+    }
+}

--- a/src/main/java/liqp/TemplateParser.java
+++ b/src/main/java/liqp/TemplateParser.java
@@ -3,6 +3,9 @@ package liqp;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+
+import org.antlr.v4.runtime.CharStreams;
 
 import liqp.parser.Flavor;
 
@@ -68,15 +71,19 @@ public class TemplateParser {
     }
 
     public Template parse(File file) throws IOException {
-        return new Template.BuiltTemplate(this, file);
+        return new Template.BuiltTemplate(this, CharStreams.fromPath(file.toPath()));
     }
 
     public Template parse(String input) {
-        return new Template.BuiltTemplate(this, input);
+        return new Template.BuiltTemplate(this, CharStreams.fromString(input));
     }
 
     public Template parse(InputStream input) throws IOException {
-        return new Template.BuiltTemplate(this, input);
+        return new Template.BuiltTemplate(this, CharStreams.fromStream(input));
+    }
+
+    public Template parse(Reader reader) throws IOException {
+        return new Template.BuiltTemplate(this, CharStreams.fromReader(reader));
     }
 
     public ParseSettings getParseSettings() {

--- a/src/main/java/liqp/blocks/Block.java
+++ b/src/main/java/liqp/blocks/Block.java
@@ -1,6 +1,7 @@
 package liqp.blocks;
 
 import liqp.Insertion;
+import liqp.ParseSettings;
 
 public abstract class Block extends Insertion {
     /**
@@ -23,7 +24,10 @@ public abstract class Block extends Insertion {
 
     /**
      * Variant of {@link #registerInsertion(Insertion)} with strict limitation to {@link Block} subtype.
+     * 
+     * @deprecated Use {@link ParseSettings}.
      */
+    @Deprecated
     public static void registerBlock(Block block) {
         registerInsertion(block);
     }

--- a/src/main/java/liqp/blocks/For.java
+++ b/src/main/java/liqp/blocks/For.java
@@ -86,7 +86,7 @@ public class For extends Block {
         int limit = attributes.get(LIMIT);
 
         if (data instanceof Inspectable) {
-            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, data);
+            LiquidSupport evaluated = context.getRenderSettings().evaluate(context.getParseSettings().mapper, data);
             data = evaluated.toLiquid();
         }
         if (data instanceof Map) {

--- a/src/main/java/liqp/filters/Absolute_Url.java
+++ b/src/main/java/liqp/filters/Absolute_Url.java
@@ -56,7 +56,7 @@ public class Absolute_Url extends Relative_Url {
                 }
                 return res;
             } catch (Exception e) {
-                if (context.renderSettings.raiseExceptionsInStrictMode) {
+                if (context.getRenderSettings().raiseExceptionsInStrictMode) {
                     throw new RuntimeException(e.getMessage(), e);
                 }
                 return res;

--- a/src/main/java/liqp/filters/Date.java
+++ b/src/main/java/liqp/filters/Date.java
@@ -30,7 +30,7 @@ public class Date extends Filter {
 
     @Override
     public Object apply(Object value, TemplateContext context, Object... params) {
-        Locale locale = context.renderSettings.locale;
+        Locale locale = context.getRenderSettings().locale;
 
         if (isArray(value) && asArray(value, context).length ==1) {
             value = asArray(value, context)[0];

--- a/src/main/java/liqp/filters/Filters.java
+++ b/src/main/java/liqp/filters/Filters.java
@@ -1,0 +1,202 @@
+package liqp.filters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An immutable map of {@link Filter}s.
+ */
+public final class Filters {
+    private final Map<String, Filter> map;
+
+    public static final Filters EMPTY = new Filters(Collections.emptyMap());
+
+    static Filters COMMON_FILTERS = Filters.of( //
+            new Abs(), //
+            new Absolute_Url(), //
+            new Append(), //
+            new At_Least(), //
+            new At_Most(), //
+            new Capitalize(), //
+            new Ceil(), //
+            new Compact(), //
+            new Concat(), //
+            new Date(), //
+            new Default(), //
+            new Divided_By(), //
+            new Downcase(), //
+            new Escape(), //
+            new Escape_Once(), //
+            new First(), //
+            new Floor(), //
+            new H(), //
+            new Join(), //
+            new Last(), //
+            new Lstrip(), //
+            new liqp.filters.Map(), //
+            new Minus(), //
+            new Modulo(), //
+            new Newline_To_Br(), //
+            new Plus(), //
+            new Prepend(), //
+            new Remove(), //
+            new Remove_First(), //
+            new Replace(), //
+            new Replace_First(), //
+            new Reverse(), //
+            new Round(), //
+            new Rstrip(), //
+            new Size(), //
+            new Slice(), //
+            new Sort(), //
+            new Sort_Natural(), //
+            new Split(), //
+            new Strip(), //
+            new Strip_HTML(), //
+            new Strip_Newlines(), //
+            new Times(), //
+            new Truncate(), //
+            new Truncatewords(), //
+            new Uniq(), //
+            new Upcase(), //
+            new Url_Decode(), //
+            new Url_Encode(), //
+            new Where() //
+    );
+
+    static Filters JEKYLL_EXTRA_FILTERS = Filters.of( //
+            new Normalize_Whitespace(), //
+            new Where_Exp(), //
+            new Relative_Url() //
+    );
+
+    public static Filters DEFAULT_FILTERS = COMMON_FILTERS;
+
+    public static Filters JEKYLL_FILTERS = COMMON_FILTERS.mergeWith(JEKYLL_EXTRA_FILTERS);
+
+    /**
+     * Returns a {@link Filters} instance with the given filters.
+     * 
+     * @param filters
+     *            The filters to add.
+     */
+    public static Filters of(Collection<Filter> filters) {
+        if (filters.isEmpty()) {
+            return EMPTY;
+        }
+        return new Filters(filters.stream().collect(Collectors.toMap(Filter::getName, Function
+                .identity())));
+    }
+
+    /**
+     * Returns a {@link Filters} instance with the given filters.
+     * 
+     * @param filters
+     *            The filters to add.
+     */
+    public static Filters of(Map<String, Filter> filters) {
+        if (filters.isEmpty()) {
+            return EMPTY;
+        }
+        return new Filters(filters);
+    }
+
+    /**
+     * Returns {@link Filters} instance with the given filters.
+     * 
+     * @param filters
+     *            The filters to add.
+     */
+    public static Filters of(Filter... filters) {
+        return of(Arrays.asList(filters));
+    }
+
+    private Filters(Map<String, Filter> filters) {
+        Objects.requireNonNull(filters);
+
+        this.map = Collections.unmodifiableMap(new HashMap<>(filters));
+    }
+
+    /**
+     * Returns the filters as an unmodifiable {@link Map}. The keys are the {@link Filter#name}.
+     * 
+     * @return The map.
+     */
+    public Map<String, Filter> getMap() {
+        return map;
+    }
+
+    /**
+     * Returns a new {@link Filters} instance that combines this instance with the filters of the other
+     * instance.
+     * 
+     * If there are filters with the same name in both instances, then the {@code other} filter takes
+     * precedence.
+     * 
+     * @param other
+     *            The other Filters instance.
+     * @return A new, merged instance.
+     */
+    public Filters mergeWith(Filters other) {
+        Objects.requireNonNull(other);
+
+        if (other == this || other.map.isEmpty()) {
+            return this;
+        } else if (this.map.isEmpty()) {
+            return other;
+        }
+
+        Map<String, Filter> newMap = new HashMap<>(map);
+        newMap.putAll(other.map);
+        return new Filters(newMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Filters)) {
+            return false;
+        }
+        return ((Filters) obj).map.equals(map);
+    }
+
+    @Override
+    public String toString() {
+        if (map.isEmpty()) {
+            return getClass().getName() + ".EMPTY";
+        } else {
+            return super.toString() + map;
+        }
+    }
+
+    /**
+     * Returns the {@link Filter} registered under the given name, or {@code null} if no such
+     * {@link Filter} exists in this {@link Filters} instance.
+     * 
+     * @param name
+     *            The name of the {@link Filter}.
+     * @return The instance.
+     */
+    public Filter get(String name) {
+        return map.get(name);
+    }
+    
+    /**
+     * Returns an unmodifiable collection of all Filters registered in this instance.
+     * 
+     * @return The collection.
+     */
+    public Collection<Filter> values() {
+        return Collections.unmodifiableCollection(map.values());
+    }
+}

--- a/src/main/java/liqp/filters/H.java
+++ b/src/main/java/liqp/filters/H.java
@@ -1,6 +1,5 @@
 package liqp.filters;
 
-import liqp.Template;
 import liqp.TemplateContext;
 
 public class H extends Filter {
@@ -12,7 +11,6 @@ public class H extends Filter {
      */
     @Override
     public Object apply(Object value, TemplateContext context, Object... params) {
-
-        return Filter.getFilter("escape").apply(value, context, params);
+        return Filters.COMMON_FILTERS.get("escape").apply(value, context, params);
     }
 }

--- a/src/main/java/liqp/filters/Relative_Url.java
+++ b/src/main/java/liqp/filters/Relative_Url.java
@@ -74,7 +74,7 @@ public class Relative_Url extends Filter {
                 }
                 return afterDecoding;
             } catch (URISyntaxException e) {
-                if (context.renderSettings.raiseExceptionsInStrictMode) {
+                if (context.getRenderSettings().raiseExceptionsInStrictMode) {
                     throw new RuntimeException(e.getMessage(), e);
                 }
                 return res;

--- a/src/main/java/liqp/filters/Size.java
+++ b/src/main/java/liqp/filters/Size.java
@@ -15,7 +15,7 @@ public class Size extends Filter {
     public Object apply(Object value, TemplateContext context, Object... params) {
 
         if (value instanceof Inspectable) {
-            LiquidSupport evaluated = context.renderSettings.evaluate(context.parseSettings.mapper, value);
+            LiquidSupport evaluated = context.getRenderSettings().evaluate(context.getParseSettings().mapper, value);
             value = evaluated.toLiquid();
         }
 

--- a/src/main/java/liqp/filters/Where_Exp.java
+++ b/src/main/java/liqp/filters/Where_Exp.java
@@ -58,8 +58,7 @@ public class Where_Exp extends Filter {
         String varName = asString(params[0], context);
         String strExpression = asString(params[1], context);
 
-        Template expression = Template.parse("{{ " + strExpression + " }}", context.parseSettings)
-                .withRenderSettings(context.renderSettings);
+        Template expression = context.getParser().parse("{{ " + strExpression + " }}");
 
         List<Object> res = new ArrayList<>();
         for (Object item: items) {

--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -66,8 +66,9 @@ public class BlockNode implements LNode {
                 builder.append(asString(value, context));
             }
 
-            if (builder.length() > context.protectionSettings.maxSizeRenderedString) {
-                throw new RuntimeException("rendered string exceeds " + context.protectionSettings.maxSizeRenderedString);
+            if (builder.length() > context.getParser().getProtectionSettings().maxSizeRenderedString) {
+                throw new RuntimeException("rendered string exceeds " + context.getParser()
+                        .getProtectionSettings().maxSizeRenderedString);
             }
         }
 

--- a/src/main/java/liqp/nodes/LookupNode.java
+++ b/src/main/java/liqp/nodes/LookupNode.java
@@ -50,11 +50,11 @@ public class LookupNode implements LNode {
             value = index.get(value, context);
         }
 
-        if(value == null && context.renderSettings.strictVariables) {
+        if(value == null && context.getRenderSettings().strictVariables) {
             RuntimeException e = new VariableNotExistException(getVariableName());
             context.addError(e);
 
-            if (context.renderSettings.raiseExceptionsInStrictMode) {
+            if (context.getRenderSettings().raiseExceptionsInStrictMode) {
                 throw e;
             }
         }

--- a/src/main/java/liqp/parser/Flavor.java
+++ b/src/main/java/liqp/parser/Flavor.java
@@ -1,13 +1,65 @@
 package liqp.parser;
 
-public enum Flavor {
+import liqp.Insertions;
+import liqp.ParseSettings;
+import liqp.TemplateParser;
+import liqp.filters.Filters;
 
-    LIQUID("snippets"),
-    JEKYLL("_includes");
+public enum Flavor {
+    LIQUID("snippets", Filters.DEFAULT_FILTERS, Insertions.STANDARD_INSERTIONS), //
+    JEKYLL("_includes", Filters.JEKYLL_FILTERS, Insertions.STANDARD_INSERTIONS);
 
     public final String snippetsFolderName;
+    private final Filters filters;
+    private final Insertions insertions;
+    private ParseSettings parseSettings;
+    private TemplateParser parser;
 
-    Flavor(String snippetsFolderName) {
+    Flavor(String snippetsFolderName, Filters filters, Insertions insertions) {
         this.snippetsFolderName = snippetsFolderName;
+        this.filters = filters;
+        this.insertions = insertions;
+    }
+
+    /**
+     * Returns the common {@link Filters} of this flavor.
+     * 
+     * @return The {@link Filters}.
+     */
+    public Filters getFilters() {
+        return filters;
+    }
+
+    /**
+     * Returns the common {@link Insertions} of this flavor.
+     * 
+     * @return The {@link Insertions}.
+     */
+    public Insertions getInsertions() {
+        return insertions;
+    }
+
+    /**
+     * Returns the default {@link ParseSettings} for this Flavor.
+     * 
+     * @return The settings.
+     */
+    public ParseSettings defaultParseSettings() {
+        if (parseSettings == null) {
+            parseSettings = new ParseSettings.Builder().withFlavor(this).build();
+        }
+        return parseSettings;
+    }
+
+    /**
+     * Returns the default {@link TemplateParser} for this Flavor.
+     * 
+     * @return The parser.
+     */
+    public TemplateParser defaultParser() {
+        if (parser == null) {
+            parser = new TemplateParser.Builder().withParseSettings(defaultParseSettings()).build();
+        }
+        return parser;
     }
 }

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -1,32 +1,116 @@
 package liqp.parser.v4;
 
-import liqp.LValue;
-import liqp.ParseSettings;
-import liqp.exceptions.LiquidException;
-import liqp.filters.Filter;
-import liqp.Insertion;
-import liqp.nodes.BlockNode;
-import liqp.nodes.*;
-import liqp.parser.Flavor;
-import liquid.parser.v4.LiquidParserBaseVisitor;
-import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.tree.TerminalNode;
+import static liquid.parser.v4.LiquidParser.And;
+import static liquid.parser.v4.LiquidParser.Eq;
+import static liquid.parser.v4.LiquidParser.Gt;
+import static liquid.parser.v4.LiquidParser.GtEq;
+import static liquid.parser.v4.LiquidParser.Lt;
+import static liquid.parser.v4.LiquidParser.LtEq;
+import static liquid.parser.v4.LiquidParser.NEq;
+import static liquid.parser.v4.LiquidParser.Or;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static liquid.parser.v4.LiquidParser.*;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import liqp.Insertion;
+import liqp.Insertions;
+import liqp.LValue;
+import liqp.ParseSettings;
+import liqp.exceptions.LiquidException;
+import liqp.filters.Filter;
+import liqp.filters.Filters;
+import liqp.nodes.AndNode;
+import liqp.nodes.AtomNode;
+import liqp.nodes.AttributeNode;
+import liqp.nodes.BlockNode;
+import liqp.nodes.ContainsNode;
+import liqp.nodes.EqNode;
+import liqp.nodes.FilterNode;
+import liqp.nodes.GtEqNode;
+import liqp.nodes.GtNode;
+import liqp.nodes.InsertionNode;
+import liqp.nodes.KeyValueNode;
+import liqp.nodes.LNode;
+import liqp.nodes.LookupNode;
+import liqp.nodes.LtEqNode;
+import liqp.nodes.LtNode;
+import liqp.nodes.NEqNode;
+import liqp.nodes.OrNode;
+import liqp.nodes.OutputNode;
+import liqp.parser.Flavor;
+import liquid.parser.v4.LiquidParser.AssignmentContext;
+import liquid.parser.v4.LiquidParser.AtomContext;
+import liquid.parser.v4.LiquidParser.Atom_othersContext;
+import liquid.parser.v4.LiquidParser.AttributeContext;
+import liquid.parser.v4.LiquidParser.BlockContext;
+import liquid.parser.v4.LiquidParser.Capture_tag_IdContext;
+import liquid.parser.v4.LiquidParser.Capture_tag_StrContext;
+import liquid.parser.v4.LiquidParser.Case_tagContext;
+import liquid.parser.v4.LiquidParser.Comment_tagContext;
+import liquid.parser.v4.LiquidParser.Continue_tagContext;
+import liquid.parser.v4.LiquidParser.Cycle_tagContext;
+import liquid.parser.v4.LiquidParser.Elsif_tagContext;
+import liquid.parser.v4.LiquidParser.ExprContext;
+import liquid.parser.v4.LiquidParser.Expr_containsContext;
+import liquid.parser.v4.LiquidParser.Expr_eqContext;
+import liquid.parser.v4.LiquidParser.Expr_logicContext;
+import liquid.parser.v4.LiquidParser.Expr_relContext;
+import liquid.parser.v4.LiquidParser.Expr_termContext;
+import liquid.parser.v4.LiquidParser.FilenameContext;
+import liquid.parser.v4.LiquidParser.FilterContext;
+import liquid.parser.v4.LiquidParser.For_arrayContext;
+import liquid.parser.v4.LiquidParser.For_attributeContext;
+import liquid.parser.v4.LiquidParser.For_rangeContext;
+import liquid.parser.v4.LiquidParser.If_tagContext;
+import liquid.parser.v4.LiquidParser.Include_tagContext;
+import liquid.parser.v4.LiquidParser.IndexContext;
+import liquid.parser.v4.LiquidParser.Jekyll_include_filenameContext;
+import liquid.parser.v4.LiquidParser.Jekyll_include_outputContext;
+import liquid.parser.v4.LiquidParser.Lookup_IdContext;
+import liquid.parser.v4.LiquidParser.Lookup_StrContext;
+import liquid.parser.v4.LiquidParser.Lookup_emptyContext;
+import liquid.parser.v4.LiquidParser.Lookup_id_indexesContext;
+import liquid.parser.v4.LiquidParser.Other_tagContext;
+import liquid.parser.v4.LiquidParser.OutputContext;
+import liquid.parser.v4.LiquidParser.Param_exprContext;
+import liquid.parser.v4.LiquidParser.Param_expr_exprContext;
+import liquid.parser.v4.LiquidParser.Param_expr_key_valueContext;
+import liquid.parser.v4.LiquidParser.ParseContext;
+import liquid.parser.v4.LiquidParser.Raw_tagContext;
+import liquid.parser.v4.LiquidParser.Simple_tagContext;
+import liquid.parser.v4.LiquidParser.Table_tagContext;
+import liquid.parser.v4.LiquidParser.TermContext;
+import liquid.parser.v4.LiquidParser.Term_BlankContext;
+import liquid.parser.v4.LiquidParser.Term_DoubleNumContext;
+import liquid.parser.v4.LiquidParser.Term_EmptyContext;
+import liquid.parser.v4.LiquidParser.Term_FalseContext;
+import liquid.parser.v4.LiquidParser.Term_LongNumContext;
+import liquid.parser.v4.LiquidParser.Term_NilContext;
+import liquid.parser.v4.LiquidParser.Term_StrContext;
+import liquid.parser.v4.LiquidParser.Term_TrueContext;
+import liquid.parser.v4.LiquidParser.Term_exprContext;
+import liquid.parser.v4.LiquidParser.Term_lookupContext;
+import liquid.parser.v4.LiquidParser.Unless_tagContext;
+import liquid.parser.v4.LiquidParser.When_tagContext;
+import liquid.parser.v4.LiquidParserBaseVisitor;
 
 public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
 
-  private Map<String, Insertion> insertions;
-  private Map<String, Filter> filters;
+  private Insertions insertions;
+  private Filters filters;
   private final ParseSettings parseSettings;
   private boolean isRootBlock = true;
 
+  @Deprecated
   public NodeVisitor(Map<String, Insertion> insertions, Map<String, Filter> filters, ParseSettings parseSettings) {
+    this(Insertions.of(insertions), Filters.of(filters), parseSettings);
+  }
 
+  public NodeVisitor(Insertions insertions, Filters filters, ParseSettings parseSettings) {
     if (insertions == null)
       throw new IllegalArgumentException("tags == null");
 

--- a/src/main/java/liqp/tags/Include.java
+++ b/src/main/java/liqp/tags/Include.java
@@ -1,23 +1,24 @@
 package liqp.tags;
 
+import java.io.File;
+
 import liqp.Template;
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
-
-import java.io.File;
 
 public class Include extends Tag {
 
     public static final String INCLUDES_DIRECTORY_KEY = "liqp@includes_directory";
     public static String DEFAULT_EXTENSION = ".liquid";
 
+    @SuppressWarnings("deprecation")
     @Override
     public Object render(TemplateContext context, LNode... nodes) {
 
         try {
             String includeResource = super.asString(nodes[0].render(context), context);
             String extension = DEFAULT_EXTENSION;
-            if(includeResource.indexOf('.') > 0) {
+            if (includeResource.indexOf('.') > 0) {
                 extension = "";
             }
             File includeResourceFile;
@@ -25,22 +26,28 @@ public class Include extends Tag {
 
             if (includesDirectory != null) {
                 includeResourceFile = new File(includesDirectory, includeResource + extension);
-            }
-            else {
-              includeResourceFile = new File(context.parseSettings.flavor.snippetsFolderName, includeResource + extension);
+            } else {
+                includeResourceFile = new File(context.parseSettings.flavor.snippetsFolderName,
+                        includeResource + extension);
             }
 
-            Template template = Template.parse(includeResourceFile, context.parseSettings, context.renderSettings);
+            Template template;
+            if (context.getParser().isLegacyMode()) {
+                template = Template.parse(includeResourceFile, context.getParseSettings(), context
+                        .getRenderSettings());
+            } else {
+                template = context.getParser().parse(includeResourceFile);
+            }
 
             // check if there's a optional "with expression"
-            if(nodes.length > 1) {
+            if (nodes.length > 1) {
                 Object value = nodes[1].render(context);
                 context.put(includeResource, value);
             }
 
             return template.renderUnguarded(context);
 
-        } catch(Exception e) {
+        } catch (Exception e) {
             if (context.renderSettings.showExceptionsFromInclude) {
                 throw new RuntimeException("problem with evaluating include", e);
             } else {

--- a/src/main/java/liqp/tags/Tag.java
+++ b/src/main/java/liqp/tags/Tag.java
@@ -24,7 +24,10 @@ public abstract class Tag extends Insertion {
     /**
      * Variant of {@link #registerInsertion(Insertion)} with strict limitation to {@link Tag} subtype.
      * For clear API and backward compatibility.
+     * 
+     * @deprecated Use {@link liqp.ParseSettings.Builder#with(Insertion)}.
      */
+    @Deprecated
     public static void registerTag(Tag tag) {
         registerInsertion(tag);
     }
@@ -37,9 +40,10 @@ public abstract class Tag extends Insertion {
      *         the name of the tag to retrieve.
      *
      * @return a tag with a specific name.
+     * @deprecated Use Insertions#get(String)
      */
+    @Deprecated
     public static Insertion getTag(String name) {
-
         Insertion tag = getInsertions().get(name);
 
         if (tag == null) {

--- a/src/test/java/liqp/ProtectionSettingsTest.java
+++ b/src/test/java/liqp/ProtectionSettingsTest.java
@@ -6,106 +6,127 @@ public class ProtectionSettingsTest {
 
     @Test
     public void testWithinMaxRenderTimeMillis() {
-        Template.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
+        TemplateParser.DEFAULT.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
                 .render();
+        
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxRenderTimeMillis(1000L).build()).build();
 
-        Template.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxRenderTimeMillis(1000L).build())
-                .render();
+        parser.parse("{% for i in (1..100) %}{{ i }}{% endfor %}").render();
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxRenderTimeMillis() {
-        Template.parse("{% for i in (1..100000) %}{{ i }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxRenderTimeMillis(1).build())
-                .render();
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxRenderTimeMillis(1).build()).build();
+
+        parser.parse("{% for i in (1..100000) %}{{ i }}{% endfor %}").render();
     }
 
     @Test
     public void testWithinMaxIterationsRange() {
-        Template.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
+        TemplateParser.DEFAULT.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
                 .render();
+        
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxIterations(1000).build()).build();
 
-        Template.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxIterations(1000).build())
+        parser.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
                 .render();
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxIterationsRange() {
-        Template.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxIterations(99).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxIterations(99).build()).build();
+
+        parser.parse("{% for i in (1..100) %}{{ i }}{% endfor %}")
                 .render();
     }
 
     @Test
     public void testWithinMaxIterationsArray() {
-        Template.parse("{% for i in array %}{{ i }}{% endfor %}")
+        TemplateParser.DEFAULT.parse("{% for i in array %}{{ i }}{% endfor %}")
                 .render("{\"array\": [1, 2, 3, 4, 5, 6, 7, 8, 9]}");
 
-        Template.parse("{% for i in array %}{{ i }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxIterations(20).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxIterations(20).build()).build();
+
+        parser.parse("{% for i in array %}{{ i }}{% endfor %}")
                 .render("{\"array\": [1, 2, 3, 4, 5, 6, 7, 8, 9]}");
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxIterationsArray() {
-        Template.parse("{% for i in array %}{{ i }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxIterations(5).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxIterations(5).build()).build();
+        
+        parser.parse("{% for i in array %}{{ i }}{% endfor %}")
                 .render("{\"array\": [1, 2, 3, 4, 5, 6, 7, 8, 9]}");
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxIterationsArray2D() {
-        Template.parse("{% for a in array %}{% for i in a %}{{ i }}{% endfor %}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxIterations(10).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxIterations(10).build()).build();
+
+        parser.parse("{% for a in array %}{% for i in a %}{{ i }}{% endfor %}{% endfor %}")
                 .render("{\"array\": [[1,2,3,4,5], [11,12,13,14,15], [21,22,23,24,25]]}");
     }
 
     @Test
     public void testWithinMaxIterationsTablerow() {
-        Template.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
+        TemplateParser.DEFAULT.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
                 .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }");
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxIterationsTablerow() {
-        Template.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxIterations(5).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxIterations(5).build()).build();
+
+        parser.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
                 .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }");
     }
 
     @Test
     public void testWithinMaxTemplateSizeBytes() {
-        Template.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
+        TemplateParser.DEFAULT.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
                 .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }");
 
-        Template.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxTemplateSizeBytes(3000).build())
-                .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }");
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxTemplateSizeBytes(3000).build()).build();
+        parser.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}").render(
+                "{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }");
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxTemplateSizeBytes() {
-        Template.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxTemplateSizeBytes(30).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxTemplateSizeBytes(30).build()).build();
+
+        parser.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
                 .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }");
     }
 
     @Test
     public void testWithinMaxSizeRenderedString() {
-        Template.parse("{% for i in (1..100) %}{{ abc }}{% endfor %}")
+        TemplateParser.DEFAULT.parse("{% for i in (1..100) %}{{ abc }}{% endfor %}")
                 .render("{\"abc\": \"abcdefghijklmnopqrstuvwxyz\"}");
 
-        Template.parse("{% for i in (1..100) %}{{ abc }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxSizeRenderedString(2700).build())
-                .render("{\"abc\": \"abcdefghijklmnopqrstuvwxyz\"}");
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxSizeRenderedString(2700).build()).build();
+
+        parser.parse("{% for i in (1..100) %}{{ abc }}{% endfor %}").render(
+                "{\"abc\": \"abcdefghijklmnopqrstuvwxyz\"}");
     }
 
     @Test(expected = RuntimeException.class)
     public void testExceedMaxSizeRenderedString() {
-        Template.parse("{% for i in (1..1000) %}{{ abc }}{% endfor %}")
-                .withProtectionSettings(new ProtectionSettings.Builder().withMaxSizeRenderedString(2500).build())
+        TemplateParser parser = new TemplateParser.Builder().withProtectionSettings(
+                new ProtectionSettings.Builder().withMaxSizeRenderedString(2500).build()).build();
+        
+        parser.parse("{% for i in (1..1000) %}{{ abc }}{% endfor %}")
                 .render("{\"abc\": \"abcdefghijklmnopqrstuvwxyz\"}");
     }
 }

--- a/src/test/java/liqp/ReadmeSamplesTest.java
+++ b/src/test/java/liqp/ReadmeSamplesTest.java
@@ -15,7 +15,7 @@ public class ReadmeSamplesTest {
         class MyParams implements Inspectable {
             public String name = "tobi";
         };
-        Template template = Template.parse("hi {{name}}");
+        Template template = TemplateParser.DEFAULT.parse("hi {{name}}");
         String rendered = template.render(new MyParams());
         assertEquals("hi tobi", rendered);
     }
@@ -28,7 +28,7 @@ public class ReadmeSamplesTest {
                 return Collections.singletonMap("name", "tobi");
             }
         };
-        Template template = Template.parse("hi {{name}}");
+        Template template = TemplateParser.DEFAULT.parse("hi {{name}}");
         String rendered = template.render(new MyLazy());
         assertEquals("hi tobi", rendered);
     }
@@ -42,10 +42,10 @@ public class ReadmeSamplesTest {
         Map<String, Object> in = Collections.singletonMap("a", new Object() {
             public String val = "tobi";
         });
+        
+        TemplateParser parser = new TemplateParser.Builder().withRenderSettings(renderSettings).build();
 
-        String res = Template.parse("hi {{a.val}}")
-                .withRenderSettings(renderSettings)
-                .render(in);
+        String res = parser.parse("hi {{a.val}}").render(in);
         assertEquals("hi tobi", res);
 //        System.out.println(res);
     }

--- a/src/test/java/liqp/RenderSettingsTest.java
+++ b/src/test/java/liqp/RenderSettingsTest.java
@@ -8,12 +8,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class RenderSettingsTest {
+    
+    protected TemplateParser parserWithStrictVariables() {
+        return new TemplateParser.Builder().withRenderSettings(new RenderSettings.Builder()
+                .withStrictVariables(true).build()).build();
+    }
+    
     @Test
     public void renderWithStrictVariables1() {
         try {
-            Template.parse("{{mu}}")
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
-                    .render();
+            parserWithStrictVariables().parse("{{mu}}").render();
         } catch (RuntimeException ex) {
             VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
             assertThat(e.getVariableName(), is("mu"));
@@ -23,9 +27,7 @@ public class RenderSettingsTest {
     @Test
     public void renderWithStrictVariables2() {
         try {
-            Template.parse("{{mu}} {{qwe.asd.zxc}}")
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
-                    .render("mu", "muValue");
+            parserWithStrictVariables().parse("{{mu}} {{qwe.asd.zxc}}").render("mu", "muValue");
         } catch (RuntimeException ex) {
             VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
             assertThat(e.getVariableName(), is("qwe.asd.zxc"));
@@ -34,16 +36,14 @@ public class RenderSettingsTest {
 
     @Test
     public void renderWithStrictVariablesInCondition1() {
-        Template.parse("{% if mu == \"somethingElse\" %}{{ badVariableName }}{% endif %}")
-                .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+        parserWithStrictVariables().parse("{% if mu == \"somethingElse\" %}{{ badVariableName }}{% endif %}")
                 .render("mu", "muValue");
     }
 
     @Test
     public void renderWithStrictVariablesInCondition2() {
         try {
-            Template.parse("{% if mu == \"muValue\" %}{{ badVariableName }}{% endif %}")
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+            parserWithStrictVariables().parse("{% if mu == \"muValue\" %}{{ badVariableName }}{% endif %}")
                     .render("mu", "muValue");
         } catch (RuntimeException ex) {
             VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
@@ -54,8 +54,7 @@ public class RenderSettingsTest {
     @Test
     public void renderWithStrictVariablesInAnd1() {
         try {
-            Template.parse("{% if mu == \"muValue\" and checkThis %}{{ badVariableName }}{% endif %}")
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+            parserWithStrictVariables().parse("{% if mu == \"muValue\" and checkThis %}{{ badVariableName }}{% endif %}")
                     .render("mu", "muValue");
         } catch (RuntimeException ex) {
             VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
@@ -65,16 +64,14 @@ public class RenderSettingsTest {
 
     @Test
     public void renderWithStrictVariablesInAnd2() {
-        Template.parse("{% if mu == \"somethingElse\" and doNotCheckThis %}{{ badVariableName }}{% endif %}")
-                .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+        parserWithStrictVariables().parse("{% if mu == \"somethingElse\" and doNotCheckThis %}{{ badVariableName }}{% endif %}")
                 .render("mu", "muValue");
     }
 
     @Test
     public void renderWithStrictVariablesInOr1() {
         try {
-            Template.parse("{% if mu == \"muValue\" or doNotCheckThis %}{{ badVariableName }}{% endif %}")
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+            parserWithStrictVariables().parse("{% if mu == \"muValue\" or doNotCheckThis %}{{ badVariableName }}{% endif %}")
                     .render("mu", "muValue");
         } catch (RuntimeException ex) {
             VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
@@ -85,8 +82,7 @@ public class RenderSettingsTest {
     @Test
     public void renderWithStrictVariablesInOr2() {
         try {
-            Template.parse("{% if mu == \"somethingElse\" or checkThis %}{{ badVariableName }}{% endif %}")
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
+            parserWithStrictVariables().parse("{% if mu == \"somethingElse\" or checkThis %}{{ badVariableName }}{% endif %}")
                     .render("mu", "muValue");
         } catch (RuntimeException ex) {
             VariableNotExistException e = (VariableNotExistException) TestUtils.getExceptionRootCause(ex);
@@ -100,8 +96,10 @@ public class RenderSettingsTest {
                 .withStrictVariables(true)
                 .withRaiseExceptionsInStrictMode(false)
                 .build();
+        
+        TemplateParser parser = new TemplateParser.Builder().withRenderSettings(renderSettings).build();
 
-        Template template = Template.parse("{{a}}{{b}}{{c}}").withRenderSettings(renderSettings);
+        Template template = parser.parse("{{a}}{{b}}{{c}}");
 
         assertThat(template.errors().size(), is(0));
 

--- a/src/test/java/liqp/StatementsTest.java
+++ b/src/test/java/liqp/StatementsTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertThat;
 
 public class StatementsTest {
 
-    /*
+/*
  * def test_true_eql_true
  *   text = %| {% if true == true %} true {% else %} false {% endif %} |
  *   expected = %|  true  |
@@ -17,7 +17,7 @@ public class StatementsTest {
     @Test
     public void true_eql_trueTest() throws Exception {
 
-        assertThat(Template.parse(" {% if true == true %} true {% else %} false {% endif %} ").render(), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if true == true %} true {% else %} false {% endif %} ").render(), is("  true  "));
     }
 
     /*
@@ -30,7 +30,7 @@ public class StatementsTest {
     @Test
     public void true_not_eql_trueTest() throws Exception {
 
-        assertThat(Template.parse(" {% if true != true %} true {% else %} false {% endif %} ").render(), is("  false  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if true != true %} true {% else %} false {% endif %} ").render(), is("  false  "));
     }
 
     /*
@@ -43,7 +43,7 @@ public class StatementsTest {
     @Test
     public void true_lq_trueTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 0 > 0 %} true {% else %} false {% endif %} ").render(), is("  false  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 0 > 0 %} true {% else %} false {% endif %} ").render(), is("  false  "));
     }
 
     /*
@@ -56,7 +56,7 @@ public class StatementsTest {
     @Test
     public void one_lq_zeroTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 1 > 0 %} true {% else %} false {% endif %} ").render(), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 1 > 0 %} true {% else %} false {% endif %} ").render(), is("  true  "));
     }
 
     /*
@@ -69,7 +69,7 @@ public class StatementsTest {
     @Test
     public void zero_lq_oneTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 0 < 1 %} true {% else %} false {% endif %} ").render(), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 0 < 1 %} true {% else %} false {% endif %} ").render(), is("  true  "));
     }
 
     /*
@@ -82,7 +82,7 @@ public class StatementsTest {
     @Test
     public void zero_lq_or_equal_oneTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 0 <= 0 %} true {% else %} false {% endif %} ").render(), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 0 <= 0 %} true {% else %} false {% endif %} ").render(), is("  true  "));
     }
 
     /*
@@ -100,9 +100,9 @@ public class StatementsTest {
     @Test
     public void zero_lq_or_equal_one_involving_nilTest() throws Exception {
 
-        assertThat(Template.parse(" {% if null <= 0 %} true {% else %} false {% endif %} ").render(), is("  false  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if null <= 0 %} true {% else %} false {% endif %} ").render(), is("  false  "));
 
-        assertThat(Template.parse(" {% if 0 <= null %} true {% else %} false {% endif %} ").render(), is("  false  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 0 <= null %} true {% else %} false {% endif %} ").render(), is("  false  "));
     }
 
     /*
@@ -115,7 +115,7 @@ public class StatementsTest {
     @Test
     public void zero_lqq_or_equal_oneTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 0 >= 0 %} true {% else %} false {% endif %} ").render(), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 0 >= 0 %} true {% else %} false {% endif %} ").render(), is("  true  "));
     }
 
     /*
@@ -128,7 +128,7 @@ public class StatementsTest {
     @Test
     public void stringsTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 'test' == 'test' %} true {% else %} false {% endif %} ").render(), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 'test' == 'test' %} true {% else %} false {% endif %} ").render(), is("  true  "));
     }
 
     /*
@@ -141,7 +141,7 @@ public class StatementsTest {
     @Test
     public void strings_not_equalTest() throws Exception {
 
-        assertThat(Template.parse(" {% if 'test' != 'test' %} true {% else %} false {% endif %} ").render(), is("  false  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if 'test' != 'test' %} true {% else %} false {% endif %} ").render(), is("  false  "));
     }
 
     /*
@@ -155,7 +155,7 @@ public class StatementsTest {
     public void var_strings_equalTest() throws Exception {
 
         assertThat(
-                Template.parse(" {% if var == \"hello there!\" %} true {% else %} false {% endif %} ")
+                TemplateParser.DEFAULT.parse(" {% if var == \"hello there!\" %} true {% else %} false {% endif %} ")
                         .render("{ \"var\" : \"hello there!\" }"),
                 is("  true  "));
     }
@@ -171,7 +171,7 @@ public class StatementsTest {
     public void var_strings_are_not_equalTest() throws Exception {
 
         assertThat(
-                Template.parse(" {% if \"hello there!\" == var %} true {% else %} false {% endif %} ")
+                TemplateParser.DEFAULT.parse(" {% if \"hello there!\" == var %} true {% else %} false {% endif %} ")
                         .render("{ \"var\" : \"hello there!\" }"),
                 is("  true  "));
     }
@@ -187,7 +187,7 @@ public class StatementsTest {
     public void var_and_long_string_are_equalTest() throws Exception {
 
         assertThat(
-                Template.parse(" {% if var == 'hello there!' %} true {% else %} false {% endif %} ")
+                TemplateParser.DEFAULT.parse(" {% if var == 'hello there!' %} true {% else %} false {% endif %} ")
                         .render("{ \"var\" : \"hello there!\" }"),
                 is("  true  "));
     }
@@ -203,7 +203,7 @@ public class StatementsTest {
     public void var_and_long_string_are_equal_backwardsTest() throws Exception {
 
         assertThat(
-                Template.parse(" {% if 'hello there!' == var %} true {% else %} false {% endif %} ")
+                TemplateParser.DEFAULT.parse(" {% if 'hello there!' == var %} true {% else %} false {% endif %} ")
                         .render("{ \"var\" : \"hello there!\" }"),
                 is("  true  "));
     }
@@ -219,7 +219,7 @@ public class StatementsTest {
     public void is_collection_emptyTest() throws Exception {
 
         assertThat(
-                Template.parse(" {% if array == empty %} true {% else %} false {% endif %} ")
+                TemplateParser.DEFAULT.parse(" {% if array == empty %} true {% else %} false {% endif %} ")
                         .render("{ \"array\" : [] }"),
                 is("  true  "));
     }
@@ -235,7 +235,7 @@ public class StatementsTest {
     public void is_not_collection_emptyTest() throws Exception {
 
         assertThat(
-                Template.parse(" {% if array == empty %} true {% else %} false {% endif %} ")
+                TemplateParser.DEFAULT.parse(" {% if array == empty %} true {% else %} false {% endif %} ")
                         .render("{ \"array\" : [1,2,3] }"),
                 is("  false  "));
     }
@@ -254,9 +254,9 @@ public class StatementsTest {
     @Test
     public void nilTest() throws Exception {
 
-        assertThat(Template.parse(" {% if var == nil %} true {% else %} false {% endif %} ").render("{ \"var\" : null }"), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if var == nil %} true {% else %} false {% endif %} ").render("{ \"var\" : null }"), is("  true  "));
 
-        assertThat(Template.parse(" {% if var == null %} true {% else %} false {% endif %} ").render("{ \"var\" : null }"), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if var == null %} true {% else %} false {% endif %} ").render("{ \"var\" : null }"), is("  true  "));
     }
 
     /*
@@ -273,8 +273,8 @@ public class StatementsTest {
     @Test
     public void not_nilTest() throws Exception {
 
-        assertThat(Template.parse(" {% if var != nil %} true {% else %} false {% endif %} ").render("{\"var\":1}"), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if var != nil %} true {% else %} false {% endif %} ").render("{\"var\":1}"), is("  true  "));
 
-        assertThat(Template.parse(" {% if var != null %} true {% else %} false {% endif %} ").render("{\"var\":1}"), is("  true  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if var != null %} true {% else %} false {% endif %} ").render("{\"var\":1}"), is("  true  "));
     }
 }

--- a/src/test/java/liqp/TestUtils.java
+++ b/src/test/java/liqp/TestUtils.java
@@ -1,12 +1,14 @@
 package liqp;
 
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+
 import liqp.filters.Filter;
+import liqp.filters.Filters;
 import liqp.nodes.LNode;
 import liqp.parser.v4.NodeVisitor;
 import liquid.parser.v4.LiquidLexer;
 import liquid.parser.v4.LiquidParser;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
 
 public final class TestUtils {
 
@@ -34,7 +36,7 @@ public final class TestUtils {
         LiquidParser parser =  new LiquidParser(new CommonTokenStream(lexer));
 
         LiquidParser.OutputContext root = parser.output();
-        NodeVisitor visitor = new NodeVisitor(Insertion.getInsertions(), Filter.getFilters(parseSettings.flavor), parseSettings);
+        NodeVisitor visitor = new NodeVisitor(Insertions.STANDARD_INSERTIONS, parseSettings.flavor.getFilters(), parseSettings);
 
         return visitor.visitOutput(root);
     }

--- a/src/test/java/liqp/blocks/CaptureTest.java
+++ b/src/test/java/liqp/blocks/CaptureTest.java
@@ -1,6 +1,7 @@
 package liqp.blocks;
 
 import liqp.Template;
+import liqp.TemplateParser;
 import liqp.exceptions.LiquidException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class CaptureTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -34,8 +35,7 @@ public class CaptureTest {
      */
     @Test
     public void capturesBlockContentInVariableTest() throws RecognitionException {
-
-        assertThat(Template.parse("{% capture 'var' %}test string{% endcapture %}{{var}}").render(), is("test string"));
+        assertThat(TemplateParser.DEFAULT.parse("{% capture 'var' %}test string{% endcapture %}{{var}}").render(), is("test string"));
     }
 
     /*
@@ -67,7 +67,7 @@ public class CaptureTest {
                 "{% endif %}\n" +
                 "{{var}}";
 
-        assertThat(Template.parse(source).render().replaceAll("\\s", ""), is("test-string"));
+        assertThat(TemplateParser.DEFAULT.parse(source).render().replaceAll("\\s", ""), is("test-string"));
     }
 
     /*
@@ -97,7 +97,7 @@ public class CaptureTest {
                 "{% endfor %}\n" +
                 "{{ first }}-{{ second }}";
 
-        assertThat(Template.parse(source).render().replaceAll("\\s", ""), is("3-3"));
+        assertThat(TemplateParser.DEFAULT.parse(source).render().replaceAll("\\s", ""), is("3-3"));
     }
 
     /*
@@ -114,7 +114,7 @@ public class CaptureTest {
         String assigns = "{ \"var\" : \"content\" }";
 
         assertThat(
-                Template.parse("{{ var2 }}{% capture var2 %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}")
+                TemplateParser.DEFAULT.parse("{{ var2 }}{% capture var2 %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}")
                         .render(assigns),
                 is("content foo content foo "));
     }
@@ -131,6 +131,6 @@ public class CaptureTest {
     @Test(expected=LiquidException.class)
     public void capture_detects_bad_syntaxTest() throws Exception {
 
-        Template.parse("{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}");
+        TemplateParser.DEFAULT.parse("{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}");
     }
 }

--- a/src/test/java/liqp/blocks/CaseTest.java
+++ b/src/test/java/liqp/blocks/CaseTest.java
@@ -1,6 +1,7 @@
 package liqp.blocks;
 
 import liqp.Template;
+import liqp.TemplateParser;
 import liqp.exceptions.LiquidException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class CaseTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -63,27 +64,27 @@ public class CaseTest {
     public void caseTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}")
                         .render("{ \"condition\":2 }"),
                 is(" its 2 "));
 
         assertThat(
-                Template.parse("{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}")
                         .render("{ \"condition\":1 }"),
                 is(" its 1 "));
 
         assertThat(
-                Template.parse("{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase %}")
                         .render("{ \"condition\":3 }"),
                 is(""));
 
         assertThat(
-                Template.parse("{% case condition %}{% when \"string here\" %} hit {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when \"string here\" %} hit {% endcase %}")
                         .render("{ \"condition\":\"string here\" }"),
                 is(" hit "));
 
         assertThat(
-                Template.parse("{% case condition %}{% when \"string here\" %} hit {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when \"string here\" %} hit {% endcase %}")
                         .render("{ \"condition\":\"bad string here\" }"),
                 is(""));
     }
@@ -110,17 +111,17 @@ public class CaseTest {
     public void case_with_elseTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% case condition %}{% when 5 %} hit {% else %} else {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when 5 %} hit {% else %} else {% endcase %}")
                         .render("{ \"condition\":5 }"),
                 is(" hit "));
 
         assertThat(
-                Template.parse("{% case condition %}{% when 5 %} hit {% else %} else {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %}{% when 5 %} hit {% else %} else {% endcase %}")
                         .render("{ \"condition\":6 }"),
                 is(" else "));
 
         assertThat(
-                Template.parse("{% case condition %} {% when 5 %} hit {% else %} else {% endcase %}")
+                TemplateParser.DEFAULT.parse("{% case condition %} {% when 5 %} hit {% else %} else {% endcase %}")
                         .render("{ \"condition\":6 }"),
                 is(" else "));
     }
@@ -138,12 +139,12 @@ public class CaseTest {
     @Test
     public void case_on_sizeTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[] }"), is(""));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1] }"), is("1"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1] }"), is("2"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1,1] }"), is(""));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1,1,1] }"), is(""));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1,1,1,1] }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[] }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1] }"), is("1"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1] }"), is("2"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1,1] }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1,1,1] }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}").render("{ \"a\":[1,1,1,1,1] }"), is(""));
     }
 
     /*
@@ -176,12 +177,12 @@ public class CaseTest {
     @Test
     public void case_on_size_with_elseTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[] }"), is("else"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1] }"), is("1"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1] }"), is("2"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1,1] }"), is("else"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1,1,1] }"), is("else"));
-        assertThat(Template.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1,1,1,1] }"), is("else"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[] }"), is("else"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1] }"), is("1"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1] }"), is("2"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1,1] }"), is("else"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1,1,1] }"), is("else"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}").render("{ \"a\":[1,1,1,1,1] }"), is("else"));
     }
 
     /*
@@ -206,10 +207,10 @@ public class CaseTest {
     @Test
     public void case_on_length_with_elseTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% case a.empty? %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("else"));
-        assertThat(Template.parse("{% case false %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("false"));
-        assertThat(Template.parse("{% case true %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("true"));
-        assertThat(Template.parse("{% case NULL %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("else"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case a.empty? %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("else"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case false %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("false"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case true %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("true"));
+        assertThat(TemplateParser.DEFAULT.parse("{% case NULL %}{% when true %}true{% when false %}false{% else %}else{% endcase %}").render(), is("else"));
     }
 
     /*
@@ -228,7 +229,7 @@ public class CaseTest {
     public void assign_from_caseTest() throws RecognitionException {
 
         String code = "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{% else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}";
-        Template template = Template.parse(code);
+        Template template = TemplateParser.DEFAULT.parse(code);
 
         assertThat(template.render("{ \"collection\" : {\"handle\" : \"menswear-jackets\"} }"), is("menswear"));
         assertThat(template.render("{ \"collection\" : {\"handle\" : \"menswear-t-shirts\"} }"), is("menswear"));
@@ -258,11 +259,11 @@ public class CaseTest {
 
         String code = "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4 %} its 4 {% endcase %}";
 
-        assertThat(Template.parse(code).render("{ \"condition\" : 1 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 2 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 3 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 4 }"), is(" its 4 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 5 }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 1 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 2 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 3 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 4 }"), is(" its 4 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 5 }"), is(""));
     }
 
     /*
@@ -286,18 +287,18 @@ public class CaseTest {
 
         String code = "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its 4 {% endcase %}";
 
-        assertThat(Template.parse(code).render("{ \"condition\" : 1 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 2 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 3 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 4 }"), is(" its 4 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : 5 }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 1 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 2 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 3 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 4 }"), is(" its 4 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 5 }"), is(""));
 
         code = "{% case condition %}{% when 1, \"string\", null %} its 1 or 2 or 3 {% when 4 %} its 4 {% endcase %}";
 
-        assertThat(Template.parse(code).render("{ \"condition\" : 1 }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : \"string\" }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : null }"), is(" its 1 or 2 or 3 "));
-        assertThat(Template.parse(code).render("{ \"condition\" : \"something else\" }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : 1 }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : \"string\" }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : null }"), is(" its 1 or 2 or 3 "));
+        assertThat(TemplateParser.DEFAULT.parse(code).render("{ \"condition\" : \"something else\" }"), is(""));
     }
 
     /*
@@ -314,11 +315,11 @@ public class CaseTest {
      */
     @Test(expected=LiquidException.class)
     public void case_detects_bad_syntax1Test() throws Exception {
-        Template.parse("{% case false %}{% when %}true{% endcase %}");
+        TemplateParser.DEFAULT.parse("{% case false %}{% when %}true{% endcase %}");
     }
 
     @Test(expected=LiquidException.class)
     public void case_detects_bad_syntax2Test() throws Exception {
-        Template.parse("{% case false %}{% huh %}true{% endcase %}");
+        TemplateParser.DEFAULT.parse("{% case false %}{% huh %}true{% endcase %}");
     }
 }

--- a/src/test/java/liqp/blocks/CommentTest.java
+++ b/src/test/java/liqp/blocks/CommentTest.java
@@ -1,6 +1,8 @@
 package liqp.blocks;
 
 import liqp.Template;
+import liqp.TemplateParser;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
@@ -19,7 +21,7 @@ public class CommentTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -54,26 +56,26 @@ public class CommentTest {
     @Test
     public void has_a_block_which_does_nothingTest() throws RecognitionException {
 
-        assertThat(Template.parse("the comment block should be removed {%comment%} be gone.. {%endcomment%} .. right?").render(),
+        assertThat(TemplateParser.DEFAULT.parse("the comment block should be removed {%comment%} be gone.. {%endcomment%} .. right?").render(),
                 is("the comment block should be removed  .. right?"));
 
-        assertThat(Template.parse("{%comment%}{%endcomment%}").render(), is(""));
-        assertThat(Template.parse("{%comment%}{% endcomment %}").render(), is(""));
-        assertThat(Template.parse("{% comment %}{%endcomment%}").render(), is(""));
-        assertThat(Template.parse("{% comment %}{% endcomment %}").render(), is(""));
-        assertThat(Template.parse("{%comment%}comment{%endcomment%}").render(), is(""));
-        assertThat(Template.parse("{% comment %}comment{% endcomment %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{%comment%}{%endcomment%}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{%comment%}{% endcomment %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% comment %}{%endcomment%}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% comment %}{% endcomment %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{%comment%}comment{%endcomment%}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% comment %}comment{% endcomment %}").render(), is(""));
 
-        assertThat(Template.parse("foo{%comment%}comment{%endcomment%}bar").render(), is("foobar"));
-        assertThat(Template.parse("foo{% comment %}comment{% endcomment %}bar").render(), is("foobar"));
-        assertThat(Template.parse("foo{%comment%} comment {%endcomment%}bar").render(), is("foobar"));
-        assertThat(Template.parse("foo{% comment %} comment {% endcomment %}bar").render(), is("foobar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo{%comment%}comment{%endcomment%}bar").render(), is("foobar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo{% comment %}comment{% endcomment %}bar").render(), is("foobar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo{%comment%} comment {%endcomment%}bar").render(), is("foobar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo{% comment %} comment {% endcomment %}bar").render(), is("foobar"));
 
-        assertThat(Template.parse("foo {%comment%} {%endcomment%} bar").render(), is("foo  bar"));
-        assertThat(Template.parse("foo {%comment%}comment{%endcomment%} bar").render(), is("foo  bar"));
-        assertThat(Template.parse("foo {%comment%} comment {%endcomment%} bar").render(), is("foo  bar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo {%comment%} {%endcomment%} bar").render(), is("foo  bar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo {%comment%}comment{%endcomment%} bar").render(), is("foo  bar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo {%comment%} comment {%endcomment%} bar").render(), is("foo  bar"));
 
-        assertThat(Template.parse("foo{%comment%}\n         {%endcomment%}bar").render(), is("foobar"));
+        assertThat(TemplateParser.DEFAULT.parse("foo{%comment%}\n         {%endcomment%}bar").render(), is("foobar"));
     }
 
     @Test
@@ -87,6 +89,6 @@ public class CommentTest {
                 "    {% endif %}\n" +
                 "{% endcomment %}";
 
-        assertThat(Template.parse(source).render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse(source).render(), is(""));
     }
 }

--- a/src/test/java/liqp/blocks/CycleTest.java
+++ b/src/test/java/liqp/blocks/CycleTest.java
@@ -1,6 +1,8 @@
 package liqp.blocks;
 
 import liqp.Template;
+import liqp.TemplateParser;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
@@ -63,7 +65,7 @@ public class CycleTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -85,14 +87,14 @@ public class CycleTest {
     @Test
     public void cycleTest() throws Exception {
 
-        assertThat(Template.parse("{%cycle \"one\", \"two\"%}").render(), is("one"));
-        assertThat(Template.parse("{%cycle \"one\", \"two\"%} {%cycle \"one\", \"two\"%}").render(), is("one two"));
-        assertThat(Template.parse("{%cycle \"\", \"two\"%} {%cycle \"\", \"two\"%}").render(), is(" two"));
+        assertThat(TemplateParser.DEFAULT.parse("{%cycle \"one\", \"two\"%}").render(), is("one"));
+        assertThat(TemplateParser.DEFAULT.parse("{%cycle \"one\", \"two\"%} {%cycle \"one\", \"two\"%}").render(), is("one two"));
+        assertThat(TemplateParser.DEFAULT.parse("{%cycle \"\", \"two\"%} {%cycle \"\", \"two\"%}").render(), is(" two"));
 
-        assertThat(Template.parse("{%cycle \"one\", \"two\"%} {%cycle \"one\", \"two\"%} {%cycle \"one\", \"two\"%}").render(),
+        assertThat(TemplateParser.DEFAULT.parse("{%cycle \"one\", \"two\"%} {%cycle \"one\", \"two\"%} {%cycle \"one\", \"two\"%}").render(),
                 is("one two one"));
 
-        assertThat(Template.parse("{%cycle \"text-align: left\", \"text-align: right\" %} {%cycle \"text-align: left\", \"text-align: right\"%}").render(),
+        assertThat(TemplateParser.DEFAULT.parse("{%cycle \"text-align: left\", \"text-align: right\" %} {%cycle \"text-align: left\", \"text-align: right\"%}").render(),
                 is("text-align: left text-align: right"));
     }
 
@@ -106,7 +108,7 @@ public class CycleTest {
     public void multiple_cyclesTest() throws Exception {
 
         assertThat(
-                Template.parse(
+                TemplateParser.DEFAULT.parse(
                         "{%cycle 1,2%} " +
                         "{%cycle 1,2%} " +
                         "{%cycle 1,2%} " +
@@ -127,7 +129,7 @@ public class CycleTest {
     public void multiple_named_cyclesTest() throws Exception {
 
         assertThat(
-                Template.parse(
+                TemplateParser.DEFAULT.parse(
                         "{%cycle 1: \"one\", \"two\" %} {%cycle 2: \"one\", \"two\" %} " +
                         "{%cycle 1: \"one\", \"two\" %} {%cycle 2: \"one\", \"two\" %} " +
                         "{%cycle 1: \"one\", \"two\" %} {%cycle 2: \"one\", \"two\" %}").render(),
@@ -147,7 +149,7 @@ public class CycleTest {
         String assigns = "{\"var1\" : 1, \"var2\" : 2 }";
 
         assertThat(
-                Template.parse(
+                TemplateParser.DEFAULT.parse(
                         "{%cycle var1: \"one\", \"two\" %} {%cycle var2: \"one\", \"two\" %} " +
                         "{%cycle var1: \"one\", \"two\" %} {%cycle var2: \"one\", \"two\" %} " +
                         "{%cycle var1: \"one\", \"two\" %} {%cycle var2: \"one\", \"two\" %}").render(assigns),
@@ -156,7 +158,7 @@ public class CycleTest {
 
     @Test
     public void testCycleInNestedScope() {
-        assertThat(Template.parse("{% cycle 1,2,3 %}"
+        assertThat(TemplateParser.DEFAULT.parse("{% cycle 1,2,3 %}"
                         + "{% assign list = \"1\" | split: \",\" %}"
                         + "{% for n in list %}"
                         + "{% cycle 1,2,3 %}"

--- a/src/test/java/liqp/blocks/ForTest.java
+++ b/src/test/java/liqp/blocks/ForTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import liqp.RenderSettings;
 import liqp.Template;
 import liqp.TemplateContext;
+import liqp.TemplateParser;
 import liqp.parser.Inspectable;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Assert;
@@ -58,7 +59,7 @@ public class ForTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(test[0] + "=" + test[1], rendered, is(test[1]));
@@ -91,10 +92,10 @@ public class ForTest {
     @Test
     public void forTest() throws RecognitionException {
 
-        assertThat(Template.parse("{%for item in array%} yo {%endfor%}").render("{\"array\":[1,2,3,4]}"), is(" yo  yo  yo  yo "));
-        assertThat(Template.parse("{%for item in array%}yo{%endfor%}").render("{\"array\":[1,2]}"), is("yoyo"));
-        assertThat(Template.parse("{%for item in array%} yo {%endfor%}").render("{\"array\":[1]}"), is(" yo "));
-        assertThat(Template.parse("{%for item in array%}{%endfor%}").render("{\"array\":[1,2]}"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} yo {%endfor%}").render("{\"array\":[1,2,3,4]}"), is(" yo  yo  yo  yo "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}yo{%endfor%}").render("{\"array\":[1,2]}"), is("yoyo"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} yo {%endfor%}").render("{\"array\":[1]}"), is(" yo "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{%endfor%}").render("{\"array\":[1,2]}"), is(""));
         assertTemplateResult("\n"
                 + "  yo\n"
                 + "\n"
@@ -122,7 +123,7 @@ public class ForTest {
      *     assert_template_result(' 1  2  3 ', '{%for item in (1..3) %} {{item}} {%endfor%}')
      *
      *     assert_raises(Liquid::ArgumentError) do
-     *       Template.parse('{% for i in (a..2) %}{% endfor %}').render!("a" => [1, 2])
+     *       TemplateParser.DEFAULT.parse('{% for i in (a..2) %}{% endfor %}').render!("a" => [1, 2])
      *     end
      *
      *     assert_template_result(' 0  1  2  3 ', '{% for item in (a..3) %} {{item}} {% endfor %}', "a" => "invalid integer")
@@ -133,7 +134,7 @@ public class ForTest {
         assertTemplateResult(" 1  2  3 ", "{%for item in (1..3) %} {{item}} {%endfor%}");
 
         try{
-            Template.parse("{% for i in (a..2) %}{% endfor %}").render("{\"a\" : [1, 2]}");
+            TemplateParser.DEFAULT.parse("{% for i in (a..2) %}{% endfor %}").render("{\"a\" : [1, 2]}");
             fail();
         } catch (Exception e) { }
 
@@ -189,12 +190,12 @@ public class ForTest {
     @Test
     public void forWithVariableTest() throws RecognitionException {
 
-        assertThat(Template.parse("{%for item in array%} {{item}} {%endfor%}").render("{\"array\":[1,2,3]}"), is(" 1  2  3 "));
-        assertThat(Template.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[1,2,3]}"), is("123"));
-        assertThat(Template.parse("{% for item in array %}{{item}}{% endfor %}").render("{\"array\":[1,2,3]}"), is("123"));
-        assertThat(Template.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[\"a\",\"b\",\"c\",\"d\"]}"), is("abcd"));
-        assertThat(Template.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[\"a\",\" \",\"b\",\" \",\"c\"]}"), is("a b c"));
-        assertThat(Template.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[\"a\",\"\",\"b\",\"\",\"c\"]}"), is("abc"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{item}} {%endfor%}").render("{\"array\":[1,2,3]}"), is(" 1  2  3 "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[1,2,3]}"), is("123"));
+        assertThat(TemplateParser.DEFAULT.parse("{% for item in array %}{{item}}{% endfor %}").render("{\"array\":[1,2,3]}"), is("123"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[\"a\",\"b\",\"c\",\"d\"]}"), is("abcd"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[\"a\",\" \",\"b\",\" \",\"c\"]}"), is("a b c"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{{item}}{%endfor%}").render("{\"array\":[\"a\",\"\",\"b\",\"\",\"c\"]}"), is("abc"));
     }
 
     /*
@@ -216,13 +217,13 @@ public class ForTest {
 
         final String assigns = "{\"array\":[1,2,3]}";
 
-        assertThat(Template.parse("{%for item in array%} {{forloop.index}}/{{forloop.length}} {%endfor%}").render(assigns), is(" 1/3  2/3  3/3 "));
-        assertThat(Template.parse("{%for item in array%} {{forloop.index}} {%endfor%}").render(assigns), is(" 1  2  3 "));
-        assertThat(Template.parse("{%for item in array%} {{forloop.index0}} {%endfor%}").render(assigns), is(" 0  1  2 "));
-        assertThat(Template.parse("{%for item in array%} {{forloop.rindex0}} {%endfor%}").render(assigns), is(" 2  1  0 "));
-        assertThat(Template.parse("{%for item in array%} {{forloop.rindex}} {%endfor%}").render(assigns), is(" 3  2  1 "));
-        assertThat(Template.parse("{%for item in array%} {{forloop.first}} {%endfor%}").render(assigns), is(" true  false  false "));
-        assertThat(Template.parse("{%for item in array%} {{forloop.last}} {%endfor%}").render(assigns), is(" false  false  true "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.index}}/{{forloop.length}} {%endfor%}").render(assigns), is(" 1/3  2/3  3/3 "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.index}} {%endfor%}").render(assigns), is(" 1  2  3 "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.index0}} {%endfor%}").render(assigns), is(" 0  1  2 "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.rindex0}} {%endfor%}").render(assigns), is(" 2  1  0 "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.rindex}} {%endfor%}").render(assigns), is(" 3  2  1 "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.first}} {%endfor%}").render(assigns), is(" true  false  false "));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%} {{forloop.last}} {%endfor%}").render(assigns), is(" false  false  true "));
     }
 
     /*
@@ -238,7 +239,7 @@ public class ForTest {
 
         final String assigns = "{\"array\":[1,2,3]}";
 
-        assertThat(Template.parse("{%for item in array%}{% if forloop.first %}+{% else %}-{% endif %}{%endfor%}").render(assigns), is("+--"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{% if forloop.first %}+{% else %}-{% endif %}{%endfor%}").render(assigns), is("+--"));
     }
 
     /*
@@ -251,9 +252,9 @@ public class ForTest {
     @Test
     public void forElseTest() throws RecognitionException {
 
-        assertThat(Template.parse("{%for item in array%}+{%else%}-{%endfor%}").render("{\"array\":[1,2,3]}"), is("+++"));
-        assertThat(Template.parse("{%for item in array%}+{%else%}-{%endfor%}").render("{\"array\":[]}"), is("-"));
-        assertThat(Template.parse("{%for item in array%}+{%else%}-{%endfor%}").render("{\"array\":null}"), is("-"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}+{%else%}-{%endfor%}").render("{\"array\":[1,2,3]}"), is("+++"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}+{%else%}-{%endfor%}").render("{\"array\":[]}"), is("-"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}+{%else%}-{%endfor%}").render("{\"array\":null}"), is("-"));
     }
 
     /*
@@ -270,10 +271,10 @@ public class ForTest {
 
         final String assigns = "{\"array\":[1,2,3,4,5,6,7,8,9,0]}";
 
-        assertThat(Template.parse("{%for i in array limit:2 %}{{ i }}{%endfor%}").render(assigns), is("12"));
-        assertThat(Template.parse("{%for i in array limit:4 %}{{ i }}{%endfor%}").render(assigns), is("1234"));
-        assertThat(Template.parse("{%for i in array limit:4 offset:2 %}{{ i }}{%endfor%}").render(assigns), is("3456"));
-        assertThat(Template.parse("{%for i in array limit: 4 offset: 2 %}{{ i }}{%endfor%}").render(assigns), is("3456"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for i in array limit:2 %}{{ i }}{%endfor%}").render(assigns), is("12"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for i in array limit:4 %}{{ i }}{%endfor%}").render(assigns), is("1234"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for i in array limit:4 offset:2 %}{{ i }}{%endfor%}").render(assigns), is("3456"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for i in array limit: 4 offset: 2 %}{{ i }}{%endfor%}").render(assigns), is("3456"));
     }
 
     /*
@@ -290,7 +291,7 @@ public class ForTest {
 
         final String assigns = "{ \"array\":[1,2,3,4,5,6,7,8,9,0], \"limit\":2, \"offset\":2 }";
 
-        assertThat(Template.parse("{%for i in array limit: limit offset: offset %}{{ i }}{%endfor%}").render(assigns), is("34"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for i in array limit: limit offset: offset %}{{ i }}{%endfor%}").render(assigns), is("34"));
     }
 
     /*
@@ -304,7 +305,7 @@ public class ForTest {
 
         final String assigns = "{ \"array\":[[1,2], [3,4], [5,6]] }";
 
-        assertThat(Template.parse("{%for item in array%}{%for i in item%}{{ i }}{%endfor%}{%endfor%}").render(assigns), is("123456"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for item in array%}{%for i in item%}{{ i }}{%endfor%}{%endfor%}").render(assigns), is("123456"));
     }
 
     /*
@@ -318,7 +319,7 @@ public class ForTest {
 
         final String assigns = "{ \"array\":[1,2,3,4,5,6,7,8,9,0] }";
 
-        assertThat(Template.parse("{%for i in array offset:7 %}{{ i }}{%endfor%}").render(assigns), is("890"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for i in array offset:7 %}{{ i }}{%endfor%}").render(assigns), is("890"));
     }
 
     /*
@@ -358,7 +359,7 @@ public class ForTest {
                 "next\n" +
                 "789";
 
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
     }
 
     /*
@@ -398,7 +399,7 @@ public class ForTest {
                 "next\n" +
                 "7";
 
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
     }
 
     /*
@@ -438,7 +439,7 @@ public class ForTest {
                 "next\n" +
                 "7890";
 
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
     }
 
     /*
@@ -473,7 +474,7 @@ public class ForTest {
                 "456\n" +
                 "next\n";
 
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
     }
 
     /*
@@ -524,19 +525,19 @@ public class ForTest {
 
         String markup = "{% for i in array.items %}{% break %}{% endfor %}";
         String expected = "";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{{ i }}{% break %}{% endfor %}";
         expected = "1";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{% break %}{{ i }}{% endfor %}";
         expected = "";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{{ i }}{% if i > 3 %}{% break %}{% endif %}{% endfor %}";
         expected = "1234";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         assigns = "{ \"array\":[[1,2],[3,4],[5,6]] }";
 
@@ -549,13 +550,13 @@ public class ForTest {
                 "{% endfor %}" +
                 "{% endfor %}";
         expected = "3456";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         assigns = "{ \"array\": { \"items\":[1,2,3,4,5] } }";
 
         markup = "{% for i in array.items %}{% if i == 9999 %}{% break %}{% endif %}{{ i }}{% endfor %}";
         expected = "12345";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
     }
 
     /*
@@ -609,23 +610,23 @@ public class ForTest {
 
         String markup = "{% for i in array.items %}{% continue %}{% endfor %}";
         String expected = "";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{{ i }}{% continue %}{% endfor %}";
         expected = "12345";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{% continue %}{{ i }}{% endfor %}";
         expected = "";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{% if i > 3 %}{% continue %}{% endif %}{{ i }}{% endfor %}";
         expected = "123";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         markup = "{% for i in array.items %}{% if i == 3 %}{% continue %}{% else %}{{ i }}{% endif %}{% endfor %}";
         expected = "1245";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         assigns = "{ \"array\":[[1,2],[3,4],[5,6]] }";
 
@@ -638,13 +639,13 @@ public class ForTest {
                 "{% endfor %}" +
                 "{% endfor %}";
         expected = "23456";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
 
         assigns = "{ \"array\": { \"items\":[1,2,3,4,5] } }";
 
         markup = "{% for i in array.items %}{% if i == 9999 %}{% continue %}{% endif %}{{ i }}{% endfor %}";
         expected = "12345";
-        assertThat(Template.parse(markup).render(assigns), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(markup).render(assigns), is(expected));
     }
 
     /*
@@ -680,11 +681,11 @@ public class ForTest {
 
         String json = "{ \"string\":\"test string\" }";
 
-        assertThat(Template.parse("{%for val in string%}{{val}}{%endfor%}").render(json), is("test string"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for val in string%}{{val}}{%endfor%}").render(json), is("test string"));
 
-        assertThat(Template.parse("{%for val in string limit:1%}{{val}}{%endfor%}").render(json), is("test string"));
+        assertThat(TemplateParser.DEFAULT.parse("{%for val in string limit:1%}{{val}}{%endfor%}").render(json), is("test string"));
 
-        assertThat(Template.parse("{%for val in string%}" +
+        assertThat(TemplateParser.DEFAULT.parse("{%for val in string%}" +
                 "{{forloop.name}}-" +
                 "{{forloop.index}}-" +
                 "{{forloop.length}}-" +
@@ -744,7 +745,7 @@ public class ForTest {
         String json = "{ \"X\": [ { \"Y\":\"foo\"}, \"test string\" ] }";
 
         // extra `name` testjson = "{ \"string\":\"test string\" }";
-        String rendered = Template.parse("{% for x in X[0].Y %}{{forloop.name}}-{{x}}{%endfor%}").render(json);
+        String rendered = TemplateParser.DEFAULT.parse("{% for x in X[0].Y %}{{forloop.name}}-{{x}}{%endfor%}").render(json);
         // when
 
         // then
@@ -759,7 +760,7 @@ public class ForTest {
     @Test
     public void blankStringNotIterableTest() throws RecognitionException {
         assertTemplateResult("", "{% for char in characters %}I WILL NOT BE OUTPUT{% endfor %}", singletonMap("characters", ""));
-        assertThat(Template.parse("{% for char in characters %}I WILL NOT BE OUTPUT{% endfor %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% for char in characters %}I WILL NOT BE OUTPUT{% endfor %}").render(), is(""));
     }
 
 
@@ -777,7 +778,7 @@ public class ForTest {
      * {% endfor %}`
      * HEREDOC
      *
-     * @template = Liquid::Template.parse(template)
+     * @template = Liquid::TemplateParser.DEFAULT.parse(template)
      * rendered = @template.render('chars' => %w[a b c])
      *
      * puts(rendered)
@@ -825,11 +826,11 @@ public class ForTest {
                 "  \n" +
                 "`";
 
-        assertThat(Template.parse(template).render(variables), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(template).render(variables), is(expected));
     }
 
     /*
-     * @template = Liquid::Template.parse("{% for item in hash %}{{ item[0] }} is {{ item[1] }};{% endfor %}")
+     * @template = Liquid::TemplateParser.DEFAULT.parse("{% for item in hash %}{{ item[0] }} is {{ item[1] }};{% endfor %}")
      *
      * puts @template.render('hash' => {'a' => 'AAA', 'b' => 'BBB'})
      */
@@ -842,7 +843,7 @@ public class ForTest {
         String template = "{% for item in hash %}{{ item[0] }} is {{ item[1] }};{% endfor %}";
 
         String expected = "a is AAA;b is BBB;";
-        String rendered = Template.parse(template).render(hash);
+        String rendered = TemplateParser.DEFAULT.parse(template).render(hash);
 
         Assert.assertThat(rendered, is(expected));
     }
@@ -856,7 +857,7 @@ public class ForTest {
         String template = "{{ x | first | map: 'rating' }}";
 
         // when
-        String rendered = Template.parse(template).render(hash);
+        String rendered = TemplateParser.DEFAULT.parse(template).render(hash);
 
         // then
         assertEquals("4.5", rendered);
@@ -869,15 +870,15 @@ public class ForTest {
         final String markup = "{%for i in array.items limit:9 %}{%endfor%}{%for i in array.items offset:continue %}{{i}}{%endfor%}" +
                 "{{ continue }}";
 
-        String rendered = Template.parse(markup).render(assigns);
+        String rendered = TemplateParser.DEFAULT.parse(markup).render(assigns);
         assertEquals("0", rendered);
     }
 
     @Test
     public void testReversedSimple() {
-        assertEquals("987654321", Template.parse("{%for i in (1..9) reversed %}{{i}}{%endfor%}").render());
-        assertEquals("121:120:", Template.parse("{%for i in (116..121) reversed offset: 4 %}{{i}}:{%endfor%}").render());
-        assertEquals("", Template.parse("{%for i in (121..116) reversed offset: 4 %}{{i}}:{%endfor%}").render());
+        assertEquals("987654321", TemplateParser.DEFAULT.parse("{%for i in (1..9) reversed %}{{i}}{%endfor%}").render());
+        assertEquals("121:120:", TemplateParser.DEFAULT.parse("{%for i in (116..121) reversed offset: 4 %}{{i}}:{%endfor%}").render());
+        assertEquals("", TemplateParser.DEFAULT.parse("{%for i in (121..116) reversed offset: 4 %}{{i}}:{%endfor%}").render());
     }
 
     /*
@@ -885,7 +886,7 @@ public class ForTest {
      *     context = Context.new(ErrorDrop.new)
      *
      *     assert_raises(StandardError) do
-     *       Liquid::Template.parse('{% for i in (1..2) %}{{ standard_error }}{% endfor %}').render!(context)
+     *       Liquid::TemplateParser.DEFAULT.parse('{% for i in (1..2) %}{{ standard_error }}{% endfor %}').render!(context)
      *     end
      *
      *     assert context.registers[:for_stack].empty?
@@ -895,9 +896,11 @@ public class ForTest {
     public void test_for_cleans_up_registers() {
         Template.ContextHolder holder = new Template.ContextHolder();
         try {
-            Template.parse("{% for i in (1..2) %}{{ standard_error }}{% endfor %}")
+            TemplateParser parser = new TemplateParser.Builder().withRenderSettings(
+                    new RenderSettings.Builder().withStrictVariables(true).build()).build();
+            
+            parser.parse("{% for i in (1..2) %}{{ standard_error }}{% endfor %}")
                     .withContextHolder(holder)
-                    .withRenderSettings(new RenderSettings.Builder().withStrictVariables(true).build())
                     .render();
             fail();
         } catch (Exception e) {
@@ -909,13 +912,13 @@ public class ForTest {
 
 
     public void assertTemplateResult(String expected, String template) {
-        assertThat(Template.parse(template).render(), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(template).render(), is(expected));
     }
 
     public void assertTemplateResult(String expected, String template, Map data) {
-        assertThat(Template.parse(template).render(data), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(template).render(data), is(expected));
     }
     public void assertTemplateResult(String expected, String template, String data) {
-        assertThat(Template.parse(template).render(data), is(expected));
+        assertThat(TemplateParser.DEFAULT.parse(template).render(data), is(expected));
     }
 }

--- a/src/test/java/liqp/blocks/IfTest.java
+++ b/src/test/java/liqp/blocks/IfTest.java
@@ -1,12 +1,14 @@
 package liqp.blocks;
 
-import liqp.Template;
-import liqp.exceptions.LiquidException;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.exceptions.LiquidException;
 
 public class IfTest {
 
@@ -19,7 +21,7 @@ public class IfTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(test[0] + " = " + test[1], rendered, is(test[1]));
@@ -35,7 +37,7 @@ public class IfTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(test[0] + "(" + json + ") = " + test[1],rendered, is(test[1]));
@@ -53,9 +55,9 @@ public class IfTest {
     @Test
     public void ifTest() throws RecognitionException {
 
-        assertThat(Template.parse(" {% if false %} this text should not go into the output {% endif %} ").render(), is("  "));
-        assertThat(Template.parse(" {% if true %} this text should go into the output {% endif %} ").render(), is("  this text should go into the output  "));
-        assertThat(Template.parse("{% if false %} you suck {% endif %} {% if true %} you rock {% endif %}?").render(), is("  you rock ?"));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if false %} this text should not go into the output {% endif %} ").render(), is("  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% if true %} this text should go into the output {% endif %} ").render(), is("  this text should go into the output  "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false %} you suck {% endif %} {% if true %} you rock {% endif %}?").render(), is("  you rock ?"));
     }
 
     /*
@@ -68,9 +70,9 @@ public class IfTest {
     @Test
     public void if_elseTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if false %} NO {% else %} YES {% endif %}").render(), is(" YES "));
-        assertThat(Template.parse("{% if true %} YES {% else %} NO {% endif %}").render(), is(" YES "));
-        assertThat(Template.parse("{% if \"foo\" %} YES {% else %} NO {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false %} NO {% else %} YES {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true %} YES {% else %} NO {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if \"foo\" %} YES {% else %} NO {% endif %}").render(), is(" YES "));
     }
 
     /*
@@ -81,7 +83,7 @@ public class IfTest {
     @Test
     public void if_booleanTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if var %} YES {% endif %}").render("{ \"var\":true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% endif %}").render("{ \"var\":true }"), is(" YES "));
     }
 
     /*
@@ -98,13 +100,13 @@ public class IfTest {
     @Test
     public void if_orTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(" YES "));
-        assertThat(Template.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":true, \"b\":false }"), is(" YES "));
-        assertThat(Template.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":false, \"b\":true }"), is(" YES "));
-        assertThat(Template.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":false, \"b\":false }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":true, \"b\":false }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":false, \"b\":true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a or b %} YES {% endif %}").render("{ \"a\":false, \"b\":false }"), is(""));
 
-        assertThat(Template.parse("{% if a or b or c %} YES {% endif %}").render("{ \"a\":false, \"b\":false, \"c\":true }"), is(" YES "));
-        assertThat(Template.parse("{% if a or b or c %} YES {% endif %}").render("{ \"a\":false, \"b\":false, \"c\":false }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a or b or c %} YES {% endif %}").render("{ \"a\":false, \"b\":false, \"c\":true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a or b or c %} YES {% endif %}").render("{ \"a\":false, \"b\":false, \"c\":false }"), is(""));
     }
 
     /*
@@ -117,9 +119,9 @@ public class IfTest {
     @Test
     public void if_or_with_operatorsTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if a == true or b == true %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(" YES "));
-        assertThat(Template.parse("{% if a == true or b == false %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(" YES "));
-        assertThat(Template.parse("{% if a == false or b == false %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a == true or b == true %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a == true or b == false %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if a == false or b == false %} YES {% endif %}").render("{ \"a\":true, \"b\":true }"), is(""));
     }
 
     /*
@@ -140,7 +142,7 @@ public class IfTest {
                 .replace("'", "\"")
                 .replace("=>", ":");
 
-        assertThat(Template.parse("{% if " + awfulMarkup + " %} YES {% endif %}").render(assigns), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if " + awfulMarkup + " %} YES {% endif %}").render(assigns), is(" YES "));
     }
 
     /*
@@ -165,8 +167,8 @@ public class IfTest {
                 .replace("'", "\"")
                 .replace("=>", ":");
 
-        assertThat(Template.parse("{% if android.name == 'Roy' %}YES{% endif %}").render(assigns), is("YES"));
-        assertThat(Template.parse("{% if order.items_count == 0 %}YES{% endif %}").render(assigns), is("YES"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if android.name == 'Roy' %}YES{% endif %}").render(assigns), is("YES"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if order.items_count == 0 %}YES{% endif %}").render(assigns), is("YES"));
     }
 
     /*
@@ -179,9 +181,9 @@ public class IfTest {
     @Test
     public void if_andTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if true and true %} YES {% endif %}").render(), is(" YES "));
-        assertThat(Template.parse("{% if false and true %} YES {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if false and true %} YES {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true and true %} YES {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false and true %} YES {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false and true %} YES {% endif %}").render(), is(""));
     }
 
     /*
@@ -192,7 +194,7 @@ public class IfTest {
     @Test
     public void hash_miss_generates_falseTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : {} }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : {} }"), is(""));
     }
 
     /*
@@ -232,36 +234,36 @@ public class IfTest {
     @Test
     public void if_from_variableTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if var %} NO {% endif %}").render("{ \"var\" : false }"), is(""));
-        assertThat(Template.parse("{% if var %} NO {% endif %}").render("{ \"var\" : null }"), is(""));
-        assertThat(Template.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : {\"bar\" : false} }"), is(""));
-        assertThat(Template.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : {} }"), is(""));
-        assertThat(Template.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : null }"), is(""));
-        assertThat(Template.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : true }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} NO {% endif %}").render("{ \"var\" : false }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} NO {% endif %}").render("{ \"var\" : null }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : {\"bar\" : false} }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : {} }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : null }"), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% endif %}").render("{ \"foo\" : true }"), is(""));
 
-        assertThat(Template.parse("{% if var %} YES {% endif %}").render("{ \"var\" : \"text\" }"), is(" YES "));
-        assertThat(Template.parse("{% if var %} YES {% endif %}").render("{ \"var\" : true }"), is(" YES "));
-        assertThat(Template.parse("{% if var %} YES {% endif %}").render("{ \"var\" : 1 }"), is(" YES "));
-        assertThat(Template.parse("{% if var %} YES {% endif %}").render("{ \"var\" : {} }"), is(" YES "));
-        assertThat(Template.parse("{% if var %} YES {% endif %}").render("{ \"var\" : [] }"), is(" YES "));
-        assertThat(Template.parse("{% if \"foo\" %} YES {% endif %}").render(), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : true} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : \"text\"} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : 1 } }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : {} } }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : [] } }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% endif %}").render("{ \"var\" : \"text\" }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% endif %}").render("{ \"var\" : true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% endif %}").render("{ \"var\" : 1 }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% endif %}").render("{ \"var\" : {} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% endif %}").render("{ \"var\" : [] }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if \"foo\" %} YES {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : true} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : \"text\"} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : 1 } }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : {} } }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : [] } }"), is(" YES "));
 
-        assertThat(Template.parse("{% if var %} NO {% else %} YES {% endif %}").render("{ \"var\" : false }"), is(" YES "));
-        assertThat(Template.parse("{% if var %} NO {% else %} YES {% endif %}").render("{ \"var\" : null }"), is(" YES "));
-        assertThat(Template.parse("{% if var %} YES {% else %} NO {% endif %}").render("{ \"var\" : true }"), is(" YES "));
-        assertThat(Template.parse("{% if \"foo\" %} YES {% else %} NO {% endif %}").render("{ \"var\" : \"text\" }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} NO {% else %} YES {% endif %}").render("{ \"var\" : false }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} NO {% else %} YES {% endif %}").render("{ \"var\" : null }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if var %} YES {% else %} NO {% endif %}").render("{ \"var\" : true }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if \"foo\" %} YES {% else %} NO {% endif %}").render("{ \"var\" : \"text\" }"), is(" YES "));
 
-        assertThat(Template.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : false} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% else %} NO {% endif %}").render("{ \"foo\" : {\"bar\" : true} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} YES {% else %} NO {% endif %}").render("{ \"foo\" : {\"bar\" : \"text\"} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"foo\" : {\"notbar\" : true} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"foo\" : {} }"), is(" YES "));
-        assertThat(Template.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"notfoo\" : {\"bar\" : true} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"foo\" : {\"bar\" : false} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% else %} NO {% endif %}").render("{ \"foo\" : {\"bar\" : true} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} YES {% else %} NO {% endif %}").render("{ \"foo\" : {\"bar\" : \"text\"} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"foo\" : {\"notbar\" : true} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"foo\" : {} }"), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if foo.bar %} NO {% else %} YES {% endif %}").render("{ \"notfoo\" : {\"bar\" : true} }"), is(" YES "));
     }
 
     /*
@@ -280,14 +282,14 @@ public class IfTest {
     @Test
     public void nested_ifTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if false %}{% if false %} NO {% endif %}{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if false %}{% if true %} NO {% endif %}{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if true %}{% if false %} NO {% endif %}{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if true %}{% if true %} YES {% endif %}{% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false %}{% if false %} NO {% endif %}{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false %}{% if true %} NO {% endif %}{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true %}{% if false %} NO {% endif %}{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true %}{% if true %} YES {% endif %}{% endif %}").render(), is(" YES "));
 
-        assertThat(Template.parse("{% if true %}{% if true %} YES {% else %} NO {% endif %}{% else %} NO {% endif %}").render(), is(" YES "));
-        assertThat(Template.parse("{% if true %}{% if false %} NO {% else %} YES {% endif %}{% else %} NO {% endif %}").render(), is(" YES "));
-        assertThat(Template.parse("{% if false %}{% if true %} NO {% else %} NONO {% endif %}{% else %} YES {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true %}{% if true %} YES {% else %} NO {% endif %}{% else %} NO {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true %}{% if false %} NO {% else %} YES {% endif %}{% else %} NO {% endif %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false %}{% if true %} NO {% else %} NONO {% endif %}{% else %} YES {% endif %}").render(), is(" YES "));
     }
 
     /*
@@ -306,15 +308,15 @@ public class IfTest {
     @Test
     public void comparisons_on_nullTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if null < 10 %} NO {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if null <= 10 %} NO {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if null >= 10 %} NO {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if null > 10 %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null < 10 %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null <= 10 %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null >= 10 %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null > 10 %} NO {% endif %}").render(), is(""));
 
-        assertThat(Template.parse("{% if 10 < null %} NO {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if 10 <= null %} NO {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if 10 >= null %} NO {% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if 10 > null %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 10 < null %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 10 <= null %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 10 >= null %} NO {% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 10 > null %} NO {% endif %}").render(), is(""));
     }
 
     /*
@@ -329,11 +331,11 @@ public class IfTest {
     @Test
     public void else_ifTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% if 0 == 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}").render(), is("0"));
-        assertThat(Template.parse("{% if 0 != 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}").render(), is("1"));
-        assertThat(Template.parse("{% if 0 != 0 %}0{% elsif 1 != 1%}1{% else %}2{% endif %}").render(), is("2"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 0 == 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}").render(), is("0"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 0 != 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}").render(), is("1"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if 0 != 0 %}0{% elsif 1 != 1%}1{% else %}2{% endif %}").render(), is("2"));
 
-        assertThat(Template.parse("{% if false %}if{% elsif true %}elsif{% endif %}").render(), is("elsif"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if false %}if{% elsif true %}elsif{% endif %}").render(), is("elsif"));
     }
 
     /*
@@ -343,7 +345,7 @@ public class IfTest {
      */
     @Test(expected=LiquidException.class)
     public void syntax_error_no_variableTest() throws RecognitionException {
-        Template.parse("{% if jerry == 1 %}").render();
+        TemplateParser.DEFAULT.parse("{% if jerry == 1 %}").render();
     }
 
     /*
@@ -354,7 +356,7 @@ public class IfTest {
     @Test(expected=LiquidException.class)
     public void syntax_error_no_expressionTest() throws RecognitionException {
 
-        Template.parse("{% if %}").render();
+        TemplateParser.DEFAULT.parse("{% if %}").render();
     }
 
     /*
@@ -405,7 +407,7 @@ public class IfTest {
      */
     @Test
     public void and_or_evaluation_orderTest() throws RecognitionException {
-        assertThat(Template.parse("{% if true or false and false %}TRUE{% else %}FALSE{% endif %}").render(), is("TRUE"));
-        assertThat(Template.parse("{% if true and false and false or true %}TRUE{% else %}FALSE{% endif %}").render(), is("FALSE"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true or false and false %}TRUE{% else %}FALSE{% endif %}").render(), is("TRUE"));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true and false and false or true %}TRUE{% else %}FALSE{% endif %}").render(), is("FALSE"));
     }
 }

--- a/src/test/java/liqp/blocks/IfchangedTest.java
+++ b/src/test/java/liqp/blocks/IfchangedTest.java
@@ -1,10 +1,12 @@
 package liqp.blocks;
 
-import liqp.Template;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class IfchangedTest {
 
@@ -29,7 +31,7 @@ public class IfchangedTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[1]));
 
             assertThat(rendered, is(test[2]));
@@ -38,7 +40,7 @@ public class IfchangedTest {
 
     @Test
     public void testIfChangedScope() {
-        String render = Template.parse("{% ifchanged %}1{% endifchanged %}{%for item in (1..4) %}{% ifchanged %}{{ item }}{% endifchanged %}{% endfor %}{% ifchanged %}4{% endifchanged %}{% ifchanged %}5{% endifchanged %}").render();
+        String render = TemplateParser.DEFAULT.parse("{% ifchanged %}1{% endifchanged %}{%for item in (1..4) %}{% ifchanged %}{{ item }}{% endifchanged %}{% endfor %}{% ifchanged %}4{% endifchanged %}{% ifchanged %}5{% endifchanged %}").render();
         assertThat(render, is("12345"));
     }
 }

--- a/src/test/java/liqp/blocks/RawTest.java
+++ b/src/test/java/liqp/blocks/RawTest.java
@@ -1,11 +1,13 @@
 package liqp.blocks;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class RawTest {
 
@@ -19,7 +21,7 @@ public class RawTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -35,7 +37,7 @@ public class RawTest {
     @Test
     public void tag_in_rawTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% raw %}{% comment %} test {% endcomment %}{% endraw %}").render(),
+        assertThat(TemplateParser.DEFAULT.parse("{% raw %}{% comment %} test {% endcomment %}{% endraw %}").render(),
                 is("{% comment %} test {% endcomment %}"));
     }
 
@@ -48,7 +50,7 @@ public class RawTest {
     @Test
     public void output_in_rawTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% raw %}{{ test }}{% endraw %}").render(),
+        assertThat(TemplateParser.DEFAULT.parse("{% raw %}{{ test }}{% endraw %}").render(),
                 is("{{ test }}"));
     }
 }

--- a/src/test/java/liqp/blocks/TablerowTest.java
+++ b/src/test/java/liqp/blocks/TablerowTest.java
@@ -1,11 +1,13 @@
 package liqp.blocks;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class TablerowTest {
 
@@ -304,7 +306,7 @@ public class TablerowTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
             assertThat(rendered, is(test[1]));
         }
@@ -326,12 +328,12 @@ public class TablerowTest {
     public void htmlTableTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}")
                         .render("{ \"numbers\":[1,2,3,4,5,6] }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n"));
 
         assertThat(
-                Template.parse("{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}")
                         .render("{ \"numbers\":[] }"),
                 is("<tr class=\"row1\">\n</tr>\n"));
     }
@@ -348,7 +350,7 @@ public class TablerowTest {
     public void htmlTableWithDifferentColsTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% tablerow n in numbers cols:5%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in numbers cols:5%} {{n}} {% endtablerow %}")
                         .render("{ \"numbers\":[1,2,3,4,5,6] }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td><td class=\"col4\"> 4 </td><td class=\"col5\"> 5 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 6 </td></tr>\n"));
     }
@@ -364,7 +366,7 @@ public class TablerowTest {
     public void htmlColCounterTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% tablerow n in numbers cols:2%}{{tablerowloop.col}}{% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in numbers cols:2%}{{tablerowloop.col}}{% endtablerow %}")
                         .render("{ \"numbers\":[1,2,3,4,5,6] }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row3\"><td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n"));
     }
@@ -384,12 +386,12 @@ public class TablerowTest {
     public void quotedFragmentTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow %}")
                         .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n"));
 
         assertThat(
-                Template.parse("{% tablerow n in collections['frontpage'] cols:3%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in collections['frontpage'] cols:3%} {{n}} {% endtablerow %}")
                         .render("{ \"collections\" : { \"frontpage\" : [1,2,3,4,5,6] } }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n"));
     }
@@ -405,7 +407,7 @@ public class TablerowTest {
     public void enumerableDropTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}")
                         .render("{ \"numbers\" : [1,2,3,4,5,6] }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n"));
     }
@@ -421,7 +423,7 @@ public class TablerowTest {
     public void offsetAndLimitTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% tablerow n in numbers cols:3 offset:1 limit:6%} {{n}} {% endtablerow %}")
+                TemplateParser.DEFAULT.parse("{% tablerow n in numbers cols:3 offset:1 limit:6%} {{n}} {% endtablerow %}")
                         .render("{ \"numbers\" : [0,1,2,3,4,5,6] }"),
                 is("<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n"));
     }
@@ -433,12 +435,12 @@ public class TablerowTest {
      */
     @Test
     public void testBlankStringNotIterable() {
-        assertThat(Template.parse("{% tablerow char in characters cols:3 %}I WILL NOT BE OUTPUT{% endtablerow %}").render(), is("<tr class=\"row1\">\n</tr>\n"));
+        assertThat(TemplateParser.DEFAULT.parse("{% tablerow char in characters cols:3 %}I WILL NOT BE OUTPUT{% endtablerow %}").render(), is("<tr class=\"row1\">\n</tr>\n"));
     }
 
     @Test
     public void testVariableScopeShouldNotAffect() {
-        assertThat(Template.parse("{% for item in array %}{% tablerow item in array%}{{ item.id }}{% endtablerow %}-->[{{ item.id }}]<--\n{% endfor %}")
+        assertThat(TemplateParser.DEFAULT.parse("{% for item in array %}{% tablerow item in array%}{{ item.id }}{% endtablerow %}-->[{{ item.id }}]<--\n{% endfor %}")
                 .render("{ \"array\" : [{\"id\" : \"id1\"},{\"id\" : \"id2\"}] }"),
                 is("<tr class=\"row1\">\n" +
                 "<td class=\"col1\">id1</td><td class=\"col2\">id2</td></tr>\n" +
@@ -450,7 +452,7 @@ public class TablerowTest {
 
     @Test
     public void testVariableShouldNotBeVisibleAfterTag() {
-        assertThat(Template.parse("{% tablerow item in array%}{{ item.id }}{% endtablerow %}{{ item.id }}")
+        assertThat(TemplateParser.DEFAULT.parse("{% tablerow item in array%}{{ item.id }}{% endtablerow %}{{ item.id }}")
                 .render("{ \"array\" : [{\"id\" : \"id1\"},{\"id\" : \"id2\"}] }"),
                 is("<tr class=\"row1\">\n" +
                         "<td class=\"col1\">id1</td><td class=\"col2\">id2</td></tr>\n"));

--- a/src/test/java/liqp/blocks/UnlessTest.java
+++ b/src/test/java/liqp/blocks/UnlessTest.java
@@ -1,11 +1,13 @@
 package liqp.blocks;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class UnlessTest {
 
@@ -22,7 +24,7 @@ public class UnlessTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -40,9 +42,9 @@ public class UnlessTest {
     @Test
     public void unlessTest() throws RecognitionException {
 
-        assertThat(Template.parse(" {% unless true %} this text should not go into the output {% endunless %} ").render(), is("  "));
-        assertThat(Template.parse(" {% unless false %} this text should go into the output {% endunless %} ").render(), is("  this text should go into the output  "));
-        assertThat(Template.parse("{% unless true %} you suck {% endunless %} {% unless false %} you rock {% endunless %}?").render(), is("  you rock ?"));
+        assertThat(TemplateParser.DEFAULT.parse(" {% unless true %} this text should not go into the output {% endunless %} ").render(), is("  "));
+        assertThat(TemplateParser.DEFAULT.parse(" {% unless false %} this text should go into the output {% endunless %} ").render(), is("  this text should go into the output  "));
+        assertThat(TemplateParser.DEFAULT.parse("{% unless true %} you suck {% endunless %} {% unless false %} you rock {% endunless %}?").render(), is("  you rock ?"));
     }
 
     /*
@@ -55,9 +57,9 @@ public class UnlessTest {
     @Test
     public void unless_elseTest() throws RecognitionException {
 
-        assertThat(Template.parse("{% unless true %} NO {% else %} YES {% endunless %}").render(), is(" YES "));
-        assertThat(Template.parse("{% unless false %} YES {% else %} NO {% endunless %}").render(), is(" YES "));
-        assertThat(Template.parse("{% unless \"foo\" %} NO {% else %} YES {% endunless %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% unless true %} NO {% else %} YES {% endunless %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% unless false %} YES {% else %} NO {% endunless %}").render(), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% unless \"foo\" %} NO {% else %} YES {% endunless %}").render(), is(" YES "));
     }
 
     /*
@@ -69,7 +71,7 @@ public class UnlessTest {
     public void unless_in_loopTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% for i in choices %}{% unless i %}{{ forloop.index }}{% endunless %}{% endfor %}")
+                TemplateParser.DEFAULT.parse("{% for i in choices %}{% unless i %}{{ forloop.index }}{% endunless %}{% endfor %}")
                         .render("{ \"choices\" : [1, null, false] }"),
                 is("23"));
     }
@@ -83,7 +85,7 @@ public class UnlessTest {
     public void unless_else_in_loopTest() throws RecognitionException {
 
         assertThat(
-                Template.parse("{% for i in choices %}{% unless i %} {{ forloop.index }} {% else %} TRUE {% endunless %}{% endfor %}")
+                TemplateParser.DEFAULT.parse("{% for i in choices %}{% unless i %} {{ forloop.index }} {% else %} TRUE {% endunless %}{% endfor %}")
                         .render("{ \"choices\" : [1, null, false] }"),
                 is(" TRUE  2  3 "));
     }

--- a/src/test/java/liqp/filters/AbsTest.java
+++ b/src/test/java/liqp/filters/AbsTest.java
@@ -1,16 +1,18 @@
 package liqp.filters;
 
-import liqp.RenderSettings;
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.RenderSettings;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class AbsTest {
 
@@ -47,7 +49,7 @@ public class AbsTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -56,11 +58,13 @@ public class AbsTest {
 
     @Test
     public void ensureDateTypeIsZero() {
-        String res = Template.parse("{{ a | abs }}").render(Collections.singletonMap("a", LocalDateTime.now()));
+        String res = TemplateParser.DEFAULT.parse("{{ a | abs }}").render(Collections.singletonMap("a", LocalDateTime.now()));
         assertEquals("0", res);
 
         RenderSettings eager = new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build();
-        res = Template.parse("{{ a | abs }}").withRenderSettings(eager).render(Collections.singletonMap("a", LocalDateTime.now()));
+        TemplateParser parser = new TemplateParser.Builder().withRenderSettings(eager).build();
+        
+        res = parser.parse("{{ a | abs }}").render(Collections.singletonMap("a", LocalDateTime.now()));
         assertEquals("0", res);
     }
 

--- a/src/test/java/liqp/filters/Absolute_UrlTest.java
+++ b/src/test/java/liqp/filters/Absolute_UrlTest.java
@@ -1,13 +1,15 @@
 package liqp.filters;
 
-import liqp.Template;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Absolute_UrlTest {
 
@@ -30,7 +32,7 @@ public class Absolute_UrlTest {
     @Test
     public void testProduceAnAbsoluteURLFromAPageURL() {
         // given
-        Template template = Template.parse("{{ '/about/my_favorite_page/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '/about/my_favorite_page/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", "base");
         
         // when
@@ -50,7 +52,7 @@ public class Absolute_UrlTest {
     @Test
     public void testEnsureTheLeadingSlash() {
         // given
-        Template template = Template.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", "/base");
 
         // when
@@ -73,7 +75,7 @@ public class Absolute_UrlTest {
     @Test
     public void testEnsureTheLeadingSlashForTheBaseurl() {
         // given
-        Template template = Template.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", "base");
 
         // when
@@ -97,7 +99,7 @@ public class Absolute_UrlTest {
     @Test
     public void testBeOkWithBlankButPresentURL() {
         // given
-        Template template = Template.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
         Map<String,Object> data = getData("", "base");
 
         // when
@@ -120,7 +122,7 @@ public class Absolute_UrlTest {
     @Test
     public void testBeOkWithANilURL() {
         // given
-        Template template = Template.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
         Map<String,Object> data = getData(null, "base");
 
         // when
@@ -143,7 +145,7 @@ public class Absolute_UrlTest {
     @Test
     public void testBeOkWithANilBaseurl() {
         // given
-        Template template = Template.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'about/my_favorite_page/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", null);
 
         // when
@@ -166,7 +168,7 @@ public class Absolute_UrlTest {
     @Test
     public void testNotPrependForwardSlashIfInputIsEmpty() {
         // given
-        Template template = Template.parse("{{ '' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", "/base");
 
         // when
@@ -189,7 +191,7 @@ public class Absolute_UrlTest {
     @Test
     public void testNotAppendForwardSlashIfInputIsSlash() {
         // given
-        Template template = Template.parse("{{ '/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", "/base");
 
         // when
@@ -212,7 +214,7 @@ public class Absolute_UrlTest {
     @Test
     public void testNotAppendForwardSlashIfInputIsSlashAndNilBaseurl() {
         // given
-        Template template = Template.parse("{{ '/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", null);
 
         // when
@@ -235,7 +237,7 @@ public class Absolute_UrlTest {
     @Test
     public void notAppendForwardSlashIfBothInputAndBaseurlAreAimplySlash() {
         // given
-        Template template = Template.parse("{{ '/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '/' | absolute_url }}");
         Map<String,Object> data = getData("http://example.com", "/");
 
         // when
@@ -258,7 +260,7 @@ public class Absolute_UrlTest {
     @Test
     public void shouldNormalizeInternationalURLs() {
         // given
-        Template template = Template.parse("{{ '' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '' | absolute_url }}");
         Map<String,Object> data = getData("http://ümlaut.example.org/", null);
 
         // when
@@ -271,7 +273,7 @@ public class Absolute_UrlTest {
     @Test
     public void shouldNormalizeInternationalURLsInPath() {
         // given
-        Template template = Template.parse("{{ 'ü' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'ü' | absolute_url }}");
         Map<String,Object> data = getData("http://ümlaut.example.org/", null);
 
         // when
@@ -290,7 +292,7 @@ public class Absolute_UrlTest {
     @Test
     public void shouldNotModifyAbsoluteURL() {
         // given
-        Template template = Template.parse("{{ 'http://example.com/' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ 'http://example.com/' | absolute_url }}");
         Map<String,Object> data = getData("http://ümlaut.example.org/", null);
 
         // when
@@ -310,7 +312,7 @@ public class Absolute_UrlTest {
     @Test
     public void shouldTransformInputURLToString() {
         // given
-        Template template = Template.parse("{{ '/my-page.html' | absolute_url }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ '/my-page.html' | absolute_url }}");
         Map<String,Object> data = getData(new Object() {
             @Override
             public String toString() {

--- a/src/test/java/liqp/filters/AppendTest.java
+++ b/src/test/java/liqp/filters/AppendTest.java
@@ -1,9 +1,8 @@
 package liqp.filters;
 
-import liqp.RenderSettings;
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -12,9 +11,12 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.RenderSettings;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class AppendTest {
 
@@ -31,7 +33,7 @@ public class AppendTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -50,8 +52,8 @@ public class AppendTest {
 
         final String assigns = "{\"a\":\"bc\", \"b\":\"d\" }";
 
-        assertThat(Template.parse("{{ a | append: 'd'}}").render(assigns), is("bcd"));
-        assertThat(Template.parse("{{ a | append: b}}").render(assigns), is("bcd"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ a | append: 'd'}}").render(assigns), is("bcd"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ a | append: b}}").render(assigns), is("bcd"));
     }
 
 
@@ -65,11 +67,11 @@ public class AppendTest {
 
         // after time
         Map<String, Object> data = Collections.singletonMap("a", t);
-        String res = Template.parse("{{ a | append: '!' }}").render(data);
+        String res = TemplateParser.DEFAULT.parse("{{ a | append: '!' }}").render(data);
         assertEquals("2007-11-01 15:25:00 +0900!", res);
 
         // before time
-        res = Template.parse("{{ '!' | append: a }}").render(data);
+        res = TemplateParser.DEFAULT.parse("{{ '!' | append: a }}").render(data);
         assertEquals("!2007-11-01 15:25:00 +0900", res);
 
     }
@@ -79,10 +81,11 @@ public class AppendTest {
         RenderSettings eager = new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build();
         Map<String, Object> data = Collections.singletonMap("a", t);
 
-        String res = Template.parse("{{ '!' | append: a }}").withRenderSettings(eager).render(data);
+        TemplateParser parser = new TemplateParser.Builder().withRenderSettings(eager).build();
+        String res = parser.parse("{{ '!' | append: a }}").render(data);
         assertEquals("!2007-11-01 15:25:00 +0900", res);
 
-        res = Template.parse("{{ a | append: '!' }}").withRenderSettings(eager).render(data);
+        res = parser.parse("{{ a | append: '!' }}").render(data);
         assertEquals("2007-11-01 15:25:00 +0900!", res);
     }
 
@@ -96,13 +99,14 @@ public class AppendTest {
         
         RenderSettings renderSettings = new RenderSettings.Builder().withDefaultTimeZone(defaultTimeZone).build();
         
+        TemplateParser parser = new TemplateParser.Builder().withRenderSettings(renderSettings).build();
+
         // is -0500 here
-        String res = Template.parse("{{ '!' | append: a }}").withRenderSettings(renderSettings).render(data);
+        String res = parser.parse("{{ '!' | append: a }}").render(data);
         assertEquals("!2020-01-01 12:59:59 -0500", res);
 
         // is -0500 here
-        res = Template.parse("{{ a | append: '!' }}").withRenderSettings(renderSettings).render(data);
+        res = parser.parse("{{ a | append: '!' }}").render(data);
         assertEquals("2020-01-01 12:59:59 -0500!", res);
-
     }
 }

--- a/src/test/java/liqp/filters/At_LeastTest.java
+++ b/src/test/java/liqp/filters/At_LeastTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class At_LeastTest {
 
@@ -37,7 +39,7 @@ public class At_LeastTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/At_MostTest.java
+++ b/src/test/java/liqp/filters/At_MostTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class At_MostTest {
 
@@ -37,7 +39,7 @@ public class At_MostTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/CapitalizeTest.java
+++ b/src/test/java/liqp/filters/CapitalizeTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class CapitalizeTest {
 
@@ -21,7 +23,7 @@ public class CapitalizeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -34,7 +36,7 @@ public class CapitalizeTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("capitalize");
+        Filter filter = Filters.COMMON_FILTERS.get("capitalize");
 
         TemplateContext context = new TemplateContext();
         assertThat(filter.apply("testing", context), is((Object)"Testing"));

--- a/src/test/java/liqp/filters/CeilTest.java
+++ b/src/test/java/liqp/filters/CeilTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class CeilTest {
 
@@ -27,7 +29,7 @@ public class CeilTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/CompactTest.java
+++ b/src/test/java/liqp/filters/CompactTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class CompactTest {
 
@@ -21,7 +23,7 @@ public class CompactTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/ConcatTest.java
+++ b/src/test/java/liqp/filters/ConcatTest.java
@@ -1,10 +1,12 @@
 package liqp.filters;
 
-import liqp.Template;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class ConcatTest {
 
@@ -27,7 +29,7 @@ public class ConcatTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));
@@ -36,13 +38,13 @@ public class ConcatTest {
 
     @Test(expected = RuntimeException.class)
     public void applyTestParamNotArray() {
-        Template template = Template.parse("{{ a | concat: c }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ a | concat: c }}");
         template.render("{ \"a\": [1, 2], \"b\": [3, 4], \"c\": \"FOO\" }");
     }
 
     @Test(expected = RuntimeException.class)
     public void applyTestNoParam() {
-        Template template = Template.parse("{{ a | concat }}");
+        Template template = TemplateParser.DEFAULT.parse("{{ a | concat }}");
         template.render("{ \"a\": [1, 2], \"b\": [3, 4], \"c\": \"FOO\" }");
     }
 }

--- a/src/test/java/liqp/filters/DefaultTest.java
+++ b/src/test/java/liqp/filters/DefaultTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class DefaultTest {
 
@@ -34,7 +36,7 @@ public class DefaultTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/Divided_ByTest.java
+++ b/src/test/java/liqp/filters/Divided_ByTest.java
@@ -1,13 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.exceptions.LiquidException;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Divided_ByTest {
 
@@ -25,7 +26,7 @@ public class Divided_ByTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -34,17 +35,17 @@ public class Divided_ByTest {
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid1() {
-        Filter.getFilter("divided_by").apply(1);
+        Filters.COMMON_FILTERS.get("divided_by").apply(1);
     }
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid2() {
-        Filter.getFilter("divided_by").apply(1, 2, 3);
+        Filters.COMMON_FILTERS.get("divided_by").apply(1, 2, 3);
     }
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid3() {
-        Filter.getFilter("divided_by").apply(15L, 0L);
+        Filters.COMMON_FILTERS.get("divided_by").apply(15L, 0L);
     }
 
     /*
@@ -53,7 +54,7 @@ public class Divided_ByTest {
      *   assert_template_result "4", "{{ 14 | divided_by:3 }}"
      *
      *   # Ruby v1.9.2-rc1, or higher, backwards compatible Float test
-     *   assert_match(/4\.(6{13,14})7/, Template.parse("{{ 14 | divided_by:'3.0' }}").render)
+     *   assert_match(/4\.(6{13,14})7/, TemplateParser.DEFAULT.parse("{{ 14 | divided_by:'3.0' }}").render)
      *
      *   assert_template_result "5", "{{ 15 | divided_by:3 }}"
      *   assert_template_result "Liquid error: divided by 0", "{{ 5 | divided_by:0 }}"
@@ -62,7 +63,7 @@ public class Divided_ByTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("divided_by");
+        Filter filter = Filters.COMMON_FILTERS.get("divided_by");
 
         assertThat(filter.apply(12L, 3L), is((Object)4L));
         assertThat(filter.apply(14L, 3L), is((Object)4L));

--- a/src/test/java/liqp/filters/DowncaseTest.java
+++ b/src/test/java/liqp/filters/DowncaseTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class DowncaseTest {
 
@@ -22,7 +24,7 @@ public class DowncaseTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -38,7 +40,7 @@ public class DowncaseTest {
     @Test
     public void applyOriginalTest() {
 
-        final Filter filter = Filter.getFilter("downcase");
+        final Filter filter = Filters.COMMON_FILTERS.get("downcase");
         TemplateContext templateContext = new TemplateContext();
         assertThat(filter.apply("Testing", templateContext), is((Object)"testing"));
         assertThat(filter.apply(null, templateContext), is((Object)""));

--- a/src/test/java/liqp/filters/EscapeTest.java
+++ b/src/test/java/liqp/filters/EscapeTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class EscapeTest {
 
@@ -25,7 +27,7 @@ public class EscapeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -41,7 +43,7 @@ public class EscapeTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("escape");
+        Filter filter = Filters.COMMON_FILTERS.get("escape");
 
         assertThat(filter.apply("<strong>", new TemplateContext()), is((Object)"&lt;strong&gt;"));
     }

--- a/src/test/java/liqp/filters/Escape_OnceTest.java
+++ b/src/test/java/liqp/filters/Escape_OnceTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class Escape_OnceTest {
 
@@ -27,7 +29,7 @@ public class Escape_OnceTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -42,10 +44,10 @@ public class Escape_OnceTest {
     @Test
     public void applyOriginalTest() {
 
-        final Filter filter = Filter.getFilter("escape_once");
+        final Filter filter = Filters.COMMON_FILTERS.get("escape_once");
 
         TemplateContext context = new TemplateContext();
-        assertThat(filter.apply(Filter.getFilter("escape").apply("<strong>", context)), is((Object)"&lt;strong&gt;"));
+        assertThat(filter.apply(Filters.COMMON_FILTERS.get("escape").apply("<strong>", context)), is((Object)"&lt;strong&gt;"));
 
         // the same test:
         assertThat(filter.apply("&lt;strong&gt;", context), is((Object)"&lt;strong&gt;"));

--- a/src/test/java/liqp/filters/FilterTest.java
+++ b/src/test/java/liqp/filters/FilterTest.java
@@ -3,6 +3,7 @@ package liqp.filters;
 import liqp.ParseSettings;
 import liqp.Template;
 import liqp.TemplateContext;
+import liqp.TemplateParser;
 import liqp.parser.Flavor;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
@@ -17,16 +18,17 @@ public class FilterTest {
 
     @Test
     public void testCustomFilter() throws RecognitionException {
-
-        Filter.registerFilter(new Filter("textilize") {
+        ParseSettings parseSettings = new ParseSettings.Builder().with(new Filter("textilize") {
             @Override
             public Object apply(Object value, TemplateContext context, Object... params) {
                 String s = super.asString(value, context).trim();
                 return "<b>" + s.substring(1, s.length() - 1) + "</b>";
             }
-        });
+        }).build();
 
-        Template template = Template.parse("{{ '*hi*' | textilize }}");
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(parseSettings).build();
+
+        Template template = parser.parse("{{ '*hi*' | textilize }}");
         String rendered = String.valueOf(template.render());
 
         assertThat(rendered, is("<b>hi</b>"));
@@ -40,12 +42,14 @@ public class FilterTest {
         ParseSettings jekyllSettings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
         ParseSettings defaultSettings = new ParseSettings.Builder().build();
 
-        Template template1 = Template.parse(templateText, jekyllSettings);
+        Template template1 = new TemplateParser.Builder().withParseSettings(jekyllSettings).build()
+                .parse(templateText);
 
         String res = template1.render();
         assertEquals("a b c", res);
 
-        Template template2 = Template.parse(templateText, defaultSettings);
+        Template template2 = new TemplateParser.Builder().withParseSettings(defaultSettings).build()
+                .parse(templateText);
         try {
             template2.render();
             fail();

--- a/src/test/java/liqp/filters/FirstTest.java
+++ b/src/test/java/liqp/filters/FirstTest.java
@@ -1,19 +1,21 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class FirstTest {
 
     @Test
     public void applyTest() throws RecognitionException {
 
-        Template template = Template.parse("{{values | first}}");
+        Template template = TemplateParser.DEFAULT.parse("{{values | first}}");
 
         String rendered = String.valueOf(template.render("{\"values\" : [\"Mu\", \"foo\", \"bar\"]}"));
 
@@ -22,7 +24,7 @@ public class FirstTest {
     
     @Test
     public void applyObjectTest() {
-    	Template template = Template.parse("{%- assign product = values | first -%}{{product.title}} {{product.price}}");
+    	Template template = TemplateParser.DEFAULT.parse("{%- assign product = values | first -%}{{product.title}} {{product.price}}");
 
         String rendered = String.valueOf(template.render("{\"values\" : [{ \"title\": \"Product 1\", \"price\": 1299 }, { \"title\": \"Product 2\", \"price\": 2999 }]}"));
 
@@ -40,7 +42,7 @@ public class FirstTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("first");
+        Filter filter = Filters.COMMON_FILTERS.get("first");
 
         TemplateContext context = new TemplateContext();
         assertThat(filter.apply(new Integer[]{1, 2, 3}, context), is((Object)1));

--- a/src/test/java/liqp/filters/FloorTest.java
+++ b/src/test/java/liqp/filters/FloorTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class FloorTest {
 
@@ -27,7 +29,7 @@ public class FloorTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/HTest.java
+++ b/src/test/java/liqp/filters/HTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class HTest {
 
@@ -24,7 +26,7 @@ public class HTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -40,7 +42,7 @@ public class HTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("h");
+        Filter filter = Filters.COMMON_FILTERS.get("h");
 
         assertThat(filter.apply("<strong>", new TemplateContext()), is((Object)"&lt;strong&gt;"));
     }

--- a/src/test/java/liqp/filters/JoinTest.java
+++ b/src/test/java/liqp/filters/JoinTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class JoinTest {
 
@@ -24,7 +26,7 @@ public class JoinTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -40,7 +42,7 @@ public class JoinTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("join");
+        Filter filter = Filters.COMMON_FILTERS.get("join");
 
         assertThat(filter.apply(new Integer[]{1,2,3,4}, context), is((Object)"1 2 3 4"));
         assertThat(filter.apply(new Integer[]{1,2,3,4}, context, " - "), is((Object)"1 - 2 - 3 - 4"));

--- a/src/test/java/liqp/filters/LastTest.java
+++ b/src/test/java/liqp/filters/LastTest.java
@@ -1,19 +1,21 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class LastTest {
 
     @Test
     public void applyTest() throws RecognitionException {
 
-        Template template = Template.parse("{{values | last}}");
+        Template template = TemplateParser.DEFAULT.parse("{{values | last}}");
 
         String rendered = String.valueOf(template.render("{\"values\" : [\"Mu\", \"foo\", \"bar\"]}"));
 
@@ -22,7 +24,7 @@ public class LastTest {
     
     @Test
     public void applyObjectTest() {
-    	Template template = Template.parse("{%- assign product = values | last -%}{{product.title}} {{product.price}}");
+    	Template template = TemplateParser.DEFAULT.parse("{%- assign product = values | last -%}{{product.title}} {{product.price}}");
 
         String rendered = String.valueOf(template.render("{\"values\" : [{ \"title\": \"Product 1\", \"price\": 1299 }, { \"title\": \"Product 2\", \"price\": 2999 }]}"));
 
@@ -40,7 +42,7 @@ public class LastTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("last");
+        Filter filter = Filters.COMMON_FILTERS.get("last");
 
         assertThat(filter.apply(new Integer[]{1, 2, 3}, context), is((Object)3));
         assertThat(filter.apply(new Integer[]{}, context), is((Object)null));

--- a/src/test/java/liqp/filters/LstripTest.java
+++ b/src/test/java/liqp/filters/LstripTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class LstripTest {
 
@@ -26,7 +28,7 @@ public class LstripTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/MapTest.java
+++ b/src/test/java/liqp/filters/MapTest.java
@@ -1,13 +1,16 @@
 package liqp.filters;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.util.HashMap;
-import liqp.Template;
-import liqp.TemplateContext;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class MapTest {
 
@@ -30,7 +33,7 @@ public class MapTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -47,7 +50,7 @@ public class MapTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("map");
+        Filter filter = Filters.COMMON_FILTERS.get("map");
 
         Object[] rendered = (Object[]) filter.apply(
                 new HashMap[]{
@@ -66,6 +69,6 @@ public class MapTest {
 
         final String json = "{\"ary\":[{\"foo\":{\"bar\":\"a\"}}, {\"foo\":{\"bar\":\"b\"}}, {\"foo\":{\"bar\":\"c\"}}]}";
 
-        assertThat(Template.parse("{{ ary | map:'foo' | map:'bar' }}").render(json), is("abc"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ ary | map:'foo' | map:'bar' }}").render(json), is("abc"));
     }
 }

--- a/src/test/java/liqp/filters/MinusTest.java
+++ b/src/test/java/liqp/filters/MinusTest.java
@@ -1,14 +1,16 @@
 package liqp.filters;
 
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class MinusTest {
 
@@ -26,7 +28,7 @@ public class MinusTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -35,12 +37,12 @@ public class MinusTest {
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid1() {
-        Filter.getFilter("minus").apply(1);
+        Filters.COMMON_FILTERS.get("minus").apply(1);
     }
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid2() {
-        Filter.getFilter("minus").apply(1, 2, 3);
+        Filters.COMMON_FILTERS.get("minus").apply(1, 2, 3);
     }
 
     /*
@@ -52,8 +54,8 @@ public class MinusTest {
     @Test
     public void applyOriginalTest() {
 
-        assertThat(Template.parse("{{ input | minus:operand }}").render("{\"input\":5, \"operand\":1}"), is((Object)"4"));
-        assertThat(Template.parse("{{ '4.3' | minus:'2' }}").render(), is((Object)"2.3"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ input | minus:operand }}").render("{\"input\":5, \"operand\":1}"), is((Object)"4"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ '4.3' | minus:'2' }}").render(), is((Object)"2.3"));
     }
 
     /*
@@ -73,7 +75,7 @@ public class MinusTest {
             ]
 
             sources.each { |source|
-              @template = Liquid::Template.parse(source)
+              @template = Liquid::TemplateParser.DEFAULT.parse(source)
               result = @template.render({})
               printf("result: '%s'\n", result)
             }
@@ -91,12 +93,12 @@ public class MinusTest {
     */
     @Test
     public void bug110() {
-        assertThat(Template.parse("{{ 5 | minus: 2 }}").render(), is((Object)"3"));
-        assertThat(Template.parse("{{ 5.0 | minus: 2 }}").render(), is((Object)"3.0"));
-        assertThat(Template.parse("{{ \"5\" | minus: 2 }}").render(), is((Object)"3"));
-        assertThat(Template.parse("{{ \"5\" | minus: 2.0 }}").render(), is((Object)"3.0"));
-        assertThat(Template.parse("{{ \"5\" | minus: \"2\" }}").render(), is((Object)"3"));
-        assertThat(Template.parse("{{ \"5\" | minus: \"2.0\" }}").render(), is((Object)"3.0"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 5 | minus: 2 }}").render(), is((Object)"3"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 5.0 | minus: 2 }}").render(), is((Object)"3.0"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \"5\" | minus: 2 }}").render(), is((Object)"3"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \"5\" | minus: 2.0 }}").render(), is((Object)"3.0"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \"5\" | minus: \"2\" }}").render(), is((Object)"3"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \"5\" | minus: \"2.0\" }}").render(), is((Object)"3.0"));
     }
 
     /*
@@ -113,7 +115,7 @@ public class MinusTest {
             ]
 
             sources.each { |source|
-              @template = Liquid::Template.parse(source)
+              @template = Liquid::TemplateParser.DEFAULT.parse(source)
               result = @template.render({})
               printf("result: '%s'\n", result)
             }
@@ -129,13 +131,13 @@ public class MinusTest {
     */
     @Test
     public void bug115() {
-        assertThat(Template.parse("{{ \" 5 \" | minus: 2 }}").render(), is((Object)"3"));
-        assertThat(Template.parse("{{ \"5\" | minus: \"  2     \" }}").render(), is((Object)"3"));
-        assertThat(Template.parse("{{ \"  5\" | minus: \"   2.0\" }}").render(), is((Object)"3.0"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \" 5 \" | minus: 2 }}").render(), is((Object)"3"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \"5\" | minus: \"  2     \" }}").render(), is((Object)"3"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ \"  5\" | minus: \"   2.0\" }}").render(), is((Object)"3.0"));
     }
 
     @Test
     public void testMinusDate() {
-        assertThat(Template.parse("{{ a | minus: 1 }}").render(Collections.singletonMap("a", LocalDateTime.now())), is((Object)"-1"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ a | minus: 1 }}").render(Collections.singletonMap("a", LocalDateTime.now())), is((Object)"-1"));
     }
 }

--- a/src/test/java/liqp/filters/ModuloTest.java
+++ b/src/test/java/liqp/filters/ModuloTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class ModuloTest {
 
@@ -23,7 +25,7 @@ public class ModuloTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -33,13 +35,13 @@ public class ModuloTest {
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid1() {
         TemplateContext context = new TemplateContext();
-        Filter.getFilter("modulo").apply(1, context);
+        Filters.COMMON_FILTERS.get("modulo").apply(1, context);
     }
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid2() {
         TemplateContext context = new TemplateContext();
-        Filter.getFilter("modulo").apply(1, context, 2, 3);
+        Filters.COMMON_FILTERS.get("modulo").apply(1, context, 2, 3);
     }
 
 
@@ -51,11 +53,11 @@ public class ModuloTest {
     @Test
     public void applyOriginalTest() {
 
-        assertThat(Template.parse("{{ 3 | modulo:2 }}").render(), is((Object)"1"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 3 | modulo:2 }}").render(), is((Object)"1"));
     }
 
     @Test
     public void testModuloWithFloated() {
-        assertThat(Template.parse("{{ 183.357 | modulo: 12 }}").render(), is((Object)"3.357"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 183.357 | modulo: 12 }}").render(), is((Object)"3.357"));
     }
 }

--- a/src/test/java/liqp/filters/Newline_To_BrTest.java
+++ b/src/test/java/liqp/filters/Newline_To_BrTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Newline_To_BrTest {
 
@@ -20,7 +22,7 @@ public class Newline_To_BrTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/PlusTest.java
+++ b/src/test/java/liqp/filters/PlusTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class PlusTest {
 
@@ -22,7 +24,7 @@ public class PlusTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -31,12 +33,12 @@ public class PlusTest {
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid1() {
-        Filter.getFilter("plus").apply(1);
+        Filters.COMMON_FILTERS.get("plus").apply(1);
     }
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid2() {
-        Filter.getFilter("plus").apply(1, 2, 3);
+        Filters.COMMON_FILTERS.get("plus").apply(1, 2, 3);
     }
 
     /*
@@ -48,7 +50,7 @@ public class PlusTest {
     @Test
     public void applyOriginalTest() {
 
-        assertThat(Template.parse("{{ 1 | plus:1 }}").render(), is((Object)"2"));
-        assertThat(Template.parse("{{ '1' | plus:'1.0' }}").render(), is((Object)"2.0"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 1 | plus:1 }}").render(), is((Object)"2"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ '1' | plus:'1.0' }}").render(), is((Object)"2.0"));
     }
 }

--- a/src/test/java/liqp/filters/PrependTest.java
+++ b/src/test/java/liqp/filters/PrependTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class PrependTest {
 
@@ -22,7 +24,7 @@ public class PrependTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -41,7 +43,7 @@ public class PrependTest {
 
         final String json = "{ \"a\":\"bc\", \"b\":\"a\" }";
 
-        assertThat(Template.parse("{{ a | prepend: 'a'}}").render(json), is("abc"));
-        assertThat(Template.parse("{{ a | prepend: b}}").render(json), is("abc"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ a | prepend: 'a'}}").render(json), is("abc"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ a | prepend: b}}").render(json), is("abc"));
     }
 }

--- a/src/test/java/liqp/filters/Relative_UrlTest.java
+++ b/src/test/java/liqp/filters/Relative_UrlTest.java
@@ -2,6 +2,7 @@ package liqp.filters;
 
 import liqp.ParseSettings;
 import liqp.Template;
+import liqp.TemplateParser;
 import liqp.parser.Flavor;
 import liqp.parser.Inspectable;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testProduceARelativeURLFromAPageURL() {
-        String res = Template.parse("{{ '/about/my_favorite_page/' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '/about/my_favorite_page/' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("/base/about/my_favorite_page/", res);
     }
@@ -34,7 +35,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testEnsureTheLeadingSlashBetweenBaseurlAndInput() {
-        String res = Template.parse("{{ 'about/my_favorite_page/' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ 'about/my_favorite_page/' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("/base/about/my_favorite_page/", res);
     }
@@ -48,14 +49,14 @@ public class Relative_UrlTest {
      */
     @Test
     public void testEnsureTheLeadingSlashForTheBaseurl() {
-        String res = Template.parse("{{ 'about/my_favorite_page/' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ 'about/my_favorite_page/' | relative_url }}")
                 .render(getData("base"));
         assertEquals("/base/about/my_favorite_page/", res);
     }
 
     @Test
     public void testNormalizeInternationalURLs() {
-        String res = Template.parse("{{ '错误.html' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '错误.html' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("/base/%E9%94%99%E8%AF%AF.html", res);
     }
@@ -73,7 +74,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testBeOkWithANilBaseurl() {
-        String res = Template.parse("{{ 'about/my_favorite_page/' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ 'about/my_favorite_page/' | relative_url }}")
                 .render(Collections.singletonMap("baseurl", null));
         assertEquals("/about/my_favorite_page/", res);
     }
@@ -90,7 +91,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testShouldNotPrependAForwardSlashIfInputIsEmpty() {
-        String res = Template.parse("{{ '' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("/base", res);
     }
@@ -107,7 +108,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testShouldNotPrependAForwardSlashIfBaseurlEndsWithASingleOne() {
-        String res = Template.parse("{{ '/css/main.css' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '/css/main.css' | relative_url }}")
                 .render(getData("/base/"));
         assertEquals("/base/css/main.css", res);
     }
@@ -124,7 +125,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testShouldNotReturnValidURIIfBaseurlEndsWithMultipleOnes() {
-        String res = Template.parse("{{ '/css/main.css' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '/css/main.css' | relative_url }}")
                 .render(getData("/base//"));
         assertEquals("/base/css/main.css", res);
     }
@@ -140,7 +141,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testNotPrependAForwardSlashIfBothInputAndBaseurlAreSimplySlashes() {
-        String res = Template.parse("{{ '/' | relative_url }}", jekyll())
+        String res = Flavor.JEKYLL.defaultParser().parse("{{ '/' | relative_url }}")
                 .render(getData("/"));
         assertEquals("/", res);
     }
@@ -160,7 +161,7 @@ public class Relative_UrlTest {
             public final String baseurl = "/baseurl/";
         });
 
-        String res = Template.parse("{{ '/my-page.html' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '/my-page.html' | relative_url }}")
                 .render(data);
         assertEquals("/baseurl/my-page.html", res);
     }
@@ -172,7 +173,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testShouldTransformProtocolRelativeUrl() {
-        String res = Template.parse("{{ '//example.com/' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '//example.com/' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("/base/example.com/", res);
     }
@@ -185,7 +186,7 @@ public class Relative_UrlTest {
      */
     @Test
     public void testShouldNotModifyAnAbsoluteUrlWithScheme() {
-        String res = Template.parse("{{ 'file:///file.html' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ 'file:///file.html' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("file:///file.html", res);
     }
@@ -198,14 +199,14 @@ public class Relative_UrlTest {
      */
     @Test
     public void testShouldNotNormalizeAbsoluteInternationalURLs() {
-        String res = Template.parse("{{ 'https://example.com/错误' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ 'https://example.com/错误' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("https://example.com/错误", res);
     }
 
     @Test
     public void testWithFullyFeaturedUrl() {
-        String res = Template.parse("{{ '/some/path?with=extra&parameters=true#anchorhere' | relative_url }}", jekyll())
+        String res = jekyllParser().parse("{{ '/some/path?with=extra&parameters=true#anchorhere' | relative_url }}")
                 .render(getData("/base"));
         assertEquals("/base/some/path?with=extra&parameters=true#anchorhere", res);
     }
@@ -217,6 +218,10 @@ public class Relative_UrlTest {
     }
 
     private ParseSettings jekyll() {
-        return new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
+        return Flavor.JEKYLL.defaultParseSettings();
+    }
+
+    private TemplateParser jekyllParser() {
+        return new TemplateParser.Builder().withParseSettings(jekyll()).build();
     }
 }

--- a/src/test/java/liqp/filters/RemoveTest.java
+++ b/src/test/java/liqp/filters/RemoveTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class RemoveTest {
 
@@ -22,7 +24,7 @@ public class RemoveTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -31,7 +33,7 @@ public class RemoveTest {
 
     @Test(expected = RuntimeException.class)
     public void applyTestInvalidPattern() throws RecognitionException {
-        Template.parse("{{ 'ababab' | remove:nil }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'ababab' | remove:nil }}").render();
     }
 
     /*
@@ -44,7 +46,7 @@ public class RemoveTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("remove");
+        Filter filter = Filters.COMMON_FILTERS.get("remove");
 
         assertThat(filter.apply("a a a a", context, "a"), is((Object)"   "));
     }

--- a/src/test/java/liqp/filters/Remove_FirstTest.java
+++ b/src/test/java/liqp/filters/Remove_FirstTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class Remove_FirstTest {
 
@@ -22,7 +24,7 @@ public class Remove_FirstTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -31,7 +33,7 @@ public class Remove_FirstTest {
 
     @Test(expected = RuntimeException.class)
     public void applyTestInvalidPattern() throws RecognitionException {
-        Template.parse("{{ 'ababab' | remove_first:nil }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'ababab' | remove_first:nil }}").render();
     }
 
     /*
@@ -44,9 +46,9 @@ public class Remove_FirstTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("remove_first");
+        Filter filter = Filters.COMMON_FILTERS.get("remove_first");
 
         assertThat(filter.apply("a a a a", context, "a "), is((Object)"a a a"));
-        assertThat(Template.parse("{{ 'a a a a' | remove_first: 'a ' }}").render(), is((Object)"a a a"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 'a a a a' | remove_first: 'a ' }}").render(), is((Object)"a a a"));
     }
 }

--- a/src/test/java/liqp/filters/ReplaceTest.java
+++ b/src/test/java/liqp/filters/ReplaceTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class ReplaceTest {
 
@@ -22,7 +24,7 @@ public class ReplaceTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -31,12 +33,12 @@ public class ReplaceTest {
 
     @Test(expected = RuntimeException.class)
     public void applyTestInvalidPattern1() throws RecognitionException {
-        Template.parse("{{ 'ababab' | replace:nil, 'A' }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'ababab' | replace:nil, 'A' }}").render();
     }
 
     @Test(expected = RuntimeException.class)
     public void applyTestInvalidPattern2() throws RecognitionException {
-        Template.parse("{{ 'ababab' | replace:'a', nil }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'ababab' | replace:'a', nil }}").render();
     }
 
     /*
@@ -49,7 +51,7 @@ public class ReplaceTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("replace");
+        Filter filter = Filters.COMMON_FILTERS.get("replace");
 
         assertThat(filter.apply("a a a a", context, "a", "b"), is((Object)"b b b b"));
     }

--- a/src/test/java/liqp/filters/Replace_FirstTest.java
+++ b/src/test/java/liqp/filters/Replace_FirstTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class Replace_FirstTest {
 
@@ -22,7 +24,7 @@ public class Replace_FirstTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -31,12 +33,12 @@ public class Replace_FirstTest {
 
     @Test(expected = RuntimeException.class)
     public void applyTestInvalidPattern1() throws RecognitionException {
-        Template.parse("{{ 'ababab' | replace_first:nil, 'A' }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'ababab' | replace_first:nil, 'A' }}").render();
     }
 
     @Test(expected = RuntimeException.class)
     public void applyTestInvalidPattern2() throws RecognitionException {
-        Template.parse("{{ 'ababab' | replace_first:'a', nil }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'ababab' | replace_first:'a', nil }}").render();
     }
 
     /*
@@ -49,9 +51,9 @@ public class Replace_FirstTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("replace_first");
+        Filter filter = Filters.COMMON_FILTERS.get("replace_first");
 
         assertThat(filter.apply("a a a a", context, "a", "b"), is((Object)"b a a a"));
-        assertThat(Template.parse("{{ 'a a a a' | replace_first: 'a', 'b' }}").render(), is("b a a a"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ 'a a a a' | replace_first: 'a', 'b' }}").render(), is("b a a a"));
     }
 }

--- a/src/test/java/liqp/filters/ReverseTest.java
+++ b/src/test/java/liqp/filters/ReverseTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class ReverseTest {
 
@@ -23,7 +25,7 @@ public class ReverseTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/RoundTest.java
+++ b/src/test/java/liqp/filters/RoundTest.java
@@ -1,10 +1,12 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.junit.Assert.assertTrue;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class RoundTest {
 
@@ -34,7 +36,7 @@ public class RoundTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertTrue(test[0] + " with data: " + test[2] + " = " + test[1] + " ,but was: " + rendered, rendered.equals(test[1]) || rendered.equals(test[1].replace('.', ',')));

--- a/src/test/java/liqp/filters/RstripTest.java
+++ b/src/test/java/liqp/filters/RstripTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class RstripTest {
 
@@ -26,7 +28,7 @@ public class RstripTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/SizeTest.java
+++ b/src/test/java/liqp/filters/SizeTest.java
@@ -1,16 +1,18 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
-import liqp.parser.Inspectable;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
+import liqp.parser.Inspectable;
 
 public class SizeTest {
 
@@ -30,7 +32,7 @@ public class SizeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -47,7 +49,7 @@ public class SizeTest {
     @Test
     public void applyOriginalTest() {
 
-        final Filter filter = Filter.getFilter("size");
+        final Filter filter = Filters.COMMON_FILTERS.get("size");
         TemplateContext context = new TemplateContext();
 
         assertThat(filter.apply(new Integer[]{1, 2, 3}, context), is( 3));

--- a/src/test/java/liqp/filters/SliceTest.java
+++ b/src/test/java/liqp/filters/SliceTest.java
@@ -1,10 +1,12 @@
 package liqp.filters;
 
-import liqp.Template;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class SliceTest {
 
@@ -50,7 +52,7 @@ public class SliceTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));
@@ -59,21 +61,21 @@ public class SliceTest {
 
     @Test(expected = RuntimeException.class)
     public void noParamsThrowsException() {
-        Template.parse("{{ 'mu' | slice }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'mu' | slice }}").render();
     }
 
     @Test(expected = RuntimeException.class)
     public void noIntegerParamThrowsException() {
-        Template.parse("{{ 'mu' | slice: false }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'mu' | slice: false }}").render();
     }
 
     @Test(expected = RuntimeException.class)
     public void noIntegersParamThrowsException() {
-        Template.parse("{{ 'mu' | slice: 1, 3.1415 }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'mu' | slice: 1, 3.1415 }}").render();
     }
 
     @Test(expected = RuntimeException.class)
     public void threeParamsThrowsException() {
-        Template.parse("{{ 'mu' | slice: 1, 2, 3 }}").render();
+        TemplateParser.DEFAULT.parse("{{ 'mu' | slice: 1, 2, 3 }}").render();
     }
 }

--- a/src/test/java/liqp/filters/SortTest.java
+++ b/src/test/java/liqp/filters/SortTest.java
@@ -1,17 +1,19 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
-import liqp.parser.Inspectable;
-import liqp.parser.LiquidSupport;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
+import liqp.parser.Inspectable;
+import liqp.parser.LiquidSupport;
 
 public class SortTest {
 
@@ -36,7 +38,7 @@ public class SortTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -52,7 +54,7 @@ public class SortTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("sort");
+        Filter filter = Filters.COMMON_FILTERS.get("sort");
 
         assertThat(filter.apply(new Integer[]{4,3,2,1}, context), is((Object)new Integer[]{1,2,3,4}));
 
@@ -93,7 +95,7 @@ public class SortTest {
 
     @Test
     public void testInspectable() {
-        Filter filter = Filter.getFilter("sort");
+        Filter filter = Filters.COMMON_FILTERS.get("sort");
 
         Inspectable[] unsortedIns = new Inspectable[]{
                 new Pojo(4), new Pojo(3), new Pojo(2), new Pojo(1)
@@ -125,7 +127,7 @@ public class SortTest {
 
     @Test
     public void testLiquidSupport() {
-        Filter filter = Filter.getFilter("sort");
+        Filter filter = Filters.COMMON_FILTERS.get("sort");
 
         Inspectable[] unsortedIns = new Inspectable[]{
                 new PojoWithSupport(4), new PojoWithSupport(3), new PojoWithSupport(2), new PojoWithSupport(1)

--- a/src/test/java/liqp/filters/Sort_NaturalTest.java
+++ b/src/test/java/liqp/filters/Sort_NaturalTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Sort_NaturalTest {
 
@@ -28,7 +30,7 @@ public class Sort_NaturalTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/SplitTest.java
+++ b/src/test/java/liqp/filters/SplitTest.java
@@ -1,13 +1,16 @@
 package liqp.filters;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.util.regex.Pattern;
-import liqp.Template;
-import liqp.TemplateContext;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class SplitTest {
 
@@ -23,7 +26,7 @@ public class SplitTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -43,7 +46,7 @@ public class SplitTest {
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
         
-        final Filter filter = Filter.getFilter("split");
+        final Filter filter = Filters.COMMON_FILTERS.get("split");
 
         assertThat(filter.apply("12~34", context, "~"), is((Object)new String[]{"12", "34"}));
         assertThat(filter.apply("A? ~ ~ ~ ,Z", context, "~ ~ ~"), is((Object)new String[]{"A? ", " ,Z"}));

--- a/src/test/java/liqp/filters/StripTest.java
+++ b/src/test/java/liqp/filters/StripTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class StripTest {
 
@@ -26,7 +28,7 @@ public class StripTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/Strip_HTMLTest.java
+++ b/src/test/java/liqp/filters/Strip_HTMLTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class Strip_HTMLTest {
 
@@ -25,7 +27,7 @@ public class Strip_HTMLTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -43,7 +45,7 @@ public class Strip_HTMLTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        Filter filter = Filter.getFilter("strip_html");
+        Filter filter = Filters.COMMON_FILTERS.get("strip_html");
 
         assertThat(filter.apply("<div>test</div>", context), is((Object)"test"));
         assertThat(filter.apply("<div id='test'>test</div>", context), is((Object)"test"));

--- a/src/test/java/liqp/filters/Strip_NewlinesTest.java
+++ b/src/test/java/liqp/filters/Strip_NewlinesTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Strip_NewlinesTest {
 
@@ -21,7 +23,7 @@ public class Strip_NewlinesTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -36,6 +38,6 @@ public class Strip_NewlinesTest {
     @Test
     public void applyOriginalTest() {
 
-        assertThat(Template.parse("{{ source | strip_newlines }}").render("source", "a\nb\nc"), is((Object)"abc"));
+        assertThat(TemplateParser.DEFAULT.parse("{{ source | strip_newlines }}").render("source", "a\nb\nc"), is((Object)"abc"));
     }
 }

--- a/src/test/java/liqp/filters/TimesTest.java
+++ b/src/test/java/liqp/filters/TimesTest.java
@@ -1,13 +1,15 @@
 package liqp.filters;
 
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class TimesTest {
 
@@ -26,7 +28,7 @@ public class TimesTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -35,12 +37,12 @@ public class TimesTest {
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid1() {
-        Filter.getFilter("times").apply(1);
+        Filters.COMMON_FILTERS.get("times").apply(1);
     }
 
     @Test(expected=RuntimeException.class)
     public void applyTestInvalid2() {
-        Filter.getFilter("times").apply(1, 2, 3);
+        Filters.COMMON_FILTERS.get("times").apply(1, 2, 3);
     }
 
     /*
@@ -58,7 +60,7 @@ public class TimesTest {
     @Test
     public void applyOriginalTest() {
 
-        Filter filter = Filter.getFilter("times");
+        Filter filter = Filters.COMMON_FILTERS.get("times");
 
         assertThat(filter.apply(3L, 4L), is((Object)12L));
         // assert_template_result "0", "{{ 'foo' | times:4 }}" // see: applyTest()

--- a/src/test/java/liqp/filters/TruncateTest.java
+++ b/src/test/java/liqp/filters/TruncateTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class TruncateTest {
 
@@ -29,7 +31,7 @@ public class TruncateTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -47,7 +49,7 @@ public class TruncateTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        final Filter filter = Filter.getFilter("truncate");
+        final Filter filter = Filters.COMMON_FILTERS.get("truncate");
 
         assertThat(filter.apply("1234567890", context, 7), is((Object)"1234..."));
         assertThat(filter.apply("1234567890", context, 20), is((Object)"1234567890"));

--- a/src/test/java/liqp/filters/TruncatewordsTest.java
+++ b/src/test/java/liqp/filters/TruncatewordsTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class TruncatewordsTest {
 
@@ -29,7 +31,7 @@ public class TruncatewordsTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -48,7 +50,7 @@ public class TruncatewordsTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        final Filter filter = Filter.getFilter("truncatewords");
+        final Filter filter = Filters.COMMON_FILTERS.get("truncatewords");
 
         assertThat(filter.apply("one two three", context, 4), is((Object)"one two three"));
         assertThat(filter.apply("one two three", context,  2), is((Object)"one two..."));

--- a/src/test/java/liqp/filters/UniqTest.java
+++ b/src/test/java/liqp/filters/UniqTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class UniqTest {
 
@@ -22,7 +24,7 @@ public class UniqTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(test[2]));
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/UpcaseTest.java
+++ b/src/test/java/liqp/filters/UpcaseTest.java
@@ -1,12 +1,14 @@
 package liqp.filters;
 
-import liqp.Template;
-import liqp.TemplateContext;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class UpcaseTest {
 
@@ -22,7 +24,7 @@ public class UpcaseTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -38,7 +40,7 @@ public class UpcaseTest {
     @Test
     public void applyOriginalTest() {
         TemplateContext context = new TemplateContext();
-        final Filter filter = Filter.getFilter("upcase");
+        final Filter filter = Filters.COMMON_FILTERS.get("upcase");
 
         assertThat(filter.apply("Testing", context), is((Object)"TESTING"));
         assertThat(filter.apply(null, context), is((Object)""));

--- a/src/test/java/liqp/filters/Url_DecodeTest.java
+++ b/src/test/java/liqp/filters/Url_DecodeTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Url_DecodeTest {
 
@@ -31,7 +33,7 @@ public class Url_DecodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/Url_EncodeTest.java
+++ b/src/test/java/liqp/filters/Url_EncodeTest.java
@@ -1,11 +1,13 @@
 package liqp.filters;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class Url_EncodeTest {
 
@@ -28,7 +30,7 @@ public class Url_EncodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/filters/Where_ExpTest.java
+++ b/src/test/java/liqp/filters/Where_ExpTest.java
@@ -1,14 +1,14 @@
 package liqp.filters;
 
-import liqp.ParseSettings;
-import liqp.Template;
-import liqp.parser.Flavor;
-import org.junit.Test;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 
-import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.parser.Flavor;
 
 public class Where_ExpTest {
 
@@ -29,7 +29,7 @@ public class Where_ExpTest {
         Map<String, Object> data = singletonMap("var", (Object) "some string");
 
         // when
-        String res = Template.parse("{{ var | where_exp: \"la\", \"le\" }}", jekyll())
+        String res = Flavor.JEKYLL.defaultParser().parse("{{ var | where_exp: \"la\", \"le\" }}")
                 .render(data);
 
         // then
@@ -323,15 +323,6 @@ public class Where_ExpTest {
     }
 
     public Template parse(String template) {
-        return Template.parse(template, jekyll());
+        return Flavor.JEKYLL.defaultParser().parse(template);
     }
-    public ParseSettings jekyll() {
-        return new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
-    }
-
-    public ParseSettings liquid() {
-        return new ParseSettings.Builder().withFlavor(Flavor.LIQUID).build();
-    }
-
-
 }

--- a/src/test/java/liqp/filters/where/JekyllWhereImplTest.java
+++ b/src/test/java/liqp/filters/where/JekyllWhereImplTest.java
@@ -1,12 +1,7 @@
 package liqp.filters.where;
 
-import liqp.LValue;
-import liqp.ParseSettings;
-import liqp.Template;
-import liqp.TemplateContext;
-import liqp.parser.Flavor;
-import liqp.parser.LiquidSupport;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,14 +13,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import liqp.LValue;
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.parser.Flavor;
+import liqp.parser.LiquidSupport;
 
 public class JekyllWhereImplTest {
-
-
     private Template parse(String input) {
-        return Template.parse(input, new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build());
+        return Flavor.JEKYLL.defaultParser().parse(input);
     }
 
     public static class ObjectEntry {

--- a/src/test/java/liqp/filters/where/LiquidWhereImplTest.java
+++ b/src/test/java/liqp/filters/where/LiquidWhereImplTest.java
@@ -21,10 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class LiquidWhereImplTest {
-
-
     private Template parse(String input) {
-        return Template.parse(input, new ParseSettings.Builder().withFlavor(Flavor.LIQUID).build());
+        return Flavor.LIQUID.defaultParser().parse(input);
     }
 
     @Before

--- a/src/test/java/liqp/nodes/AndNodeTest.java
+++ b/src/test/java/liqp/nodes/AndNodeTest.java
@@ -1,11 +1,13 @@
 package liqp.nodes;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class AndNodeTest {
 
@@ -23,7 +25,7 @@ public class AndNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/nodes/AtomNodeTest.java
+++ b/src/test/java/liqp/nodes/AtomNodeTest.java
@@ -1,11 +1,13 @@
 package liqp.nodes;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class AtomNodeTest {
 
@@ -19,7 +21,7 @@ public class AtomNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/nodes/BlockNodeTest.java
+++ b/src/test/java/liqp/nodes/BlockNodeTest.java
@@ -1,11 +1,12 @@
 package liqp.nodes;
 
-import liqp.Template;
-import liqp.TemplateContext;
-import liqp.blocks.Block;
-import liqp.tags.Tag;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
+
+import liqp.ParseSettings;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
+import liqp.blocks.Block;
 
 public class BlockNodeTest {
 
@@ -20,14 +21,15 @@ public class BlockNodeTest {
      */
     @Test
     public void customTagTest() throws RecognitionException {
-
-        Tag.registerInsertion(new Block("testtag"){
+        ParseSettings parseSettings = new ParseSettings.Builder().with(new Block("testtag"){
             @Override
             public Object render(TemplateContext context, LNode... nodes) {
                 return null;
             }
-        });
+        }).build();
+        
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(parseSettings).build();
 
-        Template.parse("{% testtag %} {% endtesttag %}").render();
+        parser.parse("{% testtag %} {% endtesttag %}").render();
     }
 }

--- a/src/test/java/liqp/nodes/ContainsNodeTest.java
+++ b/src/test/java/liqp/nodes/ContainsNodeTest.java
@@ -1,9 +1,10 @@
 package liqp.nodes;
 
-import liqp.Template;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import liqp.TemplateParser;
 
 public class ContainsNodeTest {
     @Test
@@ -12,7 +13,7 @@ public class ContainsNodeTest {
         String data = "{ \"obj\" : { \"groups\" : [1, 2] } }";
 
         // when
-        String rendered = Template.parse("{{obj.groups contains 1}}").render(data);
+        String rendered = TemplateParser.DEFAULT.parse("{{obj.groups contains 1}}").render(data);
 
         // then
         assertEquals("true", rendered);

--- a/src/test/java/liqp/nodes/EqNodeTest.java
+++ b/src/test/java/liqp/nodes/EqNodeTest.java
@@ -1,11 +1,13 @@
 package liqp.nodes;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class EqNodeTest {
 
@@ -21,7 +23,7 @@ public class EqNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -50,20 +52,20 @@ public class EqNodeTest {
     @Test
     public void illegal_symbolsTest() throws Exception {
 
-        assertThat(Template.parse("{% if true == empty %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if true == null %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if true == blank %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true == empty %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true == null %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if true == blank %}?{% endif %}").render(), is(""));
 
-        assertThat(Template.parse("{% if empty == true %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if empty == null %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if empty == blank %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if empty == true %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if empty == null %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if empty == blank %}?{% endif %}").render(), is(""));
 
-        assertThat(Template.parse("{% if null == true %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if null == empty %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if null == blank %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null == true %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null == empty %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if null == blank %}?{% endif %}").render(), is(""));
 
-        assertThat(Template.parse("{% if blank == true %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if blank == empty %}?{% endif %}").render(), is(""));
-        assertThat(Template.parse("{% if blank == null %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if blank == true %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if blank == empty %}?{% endif %}").render(), is(""));
+        assertThat(TemplateParser.DEFAULT.parse("{% if blank == null %}?{% endif %}").render(), is(""));
     }
 }

--- a/src/test/java/liqp/nodes/GtEqNodeTest.java
+++ b/src/test/java/liqp/nodes/GtEqNodeTest.java
@@ -1,10 +1,8 @@
 package liqp.nodes;
 
-import liqp.Template;
-import liqp.TemplateTest;
-import liqp.parser.Inspectable;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -14,9 +12,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 
 public class GtEqNodeTest {
 
@@ -34,7 +36,7 @@ public class GtEqNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat("template: [" + test[0]+"], expected:["+test[1]+"], real: [" + rendered + "]",rendered, is(test[1]));
@@ -52,13 +54,13 @@ public class GtEqNodeTest {
             public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
         };
 
-        String value = Template.parse("{% if a >= a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a >= a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a >= d %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= d %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
     }
 
@@ -70,11 +72,11 @@ public class GtEqNodeTest {
         data.put("b", new TemplateTest.ComparableBase(9));
         data.put("c", new TemplateTest.ComparableBase(11));
 
-        String value = Template.parse("{% if a >= a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a >= a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
     }
 }

--- a/src/test/java/liqp/nodes/GtNodeTest.java
+++ b/src/test/java/liqp/nodes/GtNodeTest.java
@@ -1,10 +1,8 @@
 package liqp.nodes;
 
-import liqp.Template;
-import liqp.TemplateTest;
-import liqp.parser.Inspectable;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -14,9 +12,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 
 public class GtNodeTest {
 
@@ -34,7 +36,7 @@ public class GtNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -52,13 +54,13 @@ public class GtNodeTest {
             public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
         };
 
-        String value = Template.parse("{% if a > a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a > a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a > b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a > b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a > c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a > c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a > d %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a > d %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
     }
 
@@ -70,11 +72,11 @@ public class GtNodeTest {
         data.put("b", new TemplateTest.ComparableBase(9));
         data.put("c", new TemplateTest.ComparableBase(11));
 
-        String value = Template.parse("{% if a > a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a > a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a >= c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
     }
 }

--- a/src/test/java/liqp/nodes/LookupNodeTest.java
+++ b/src/test/java/liqp/nodes/LookupNodeTest.java
@@ -1,15 +1,18 @@
 package liqp.nodes;
 
-import java.util.HashMap;
-import java.util.Map;
-import liqp.Template;
-import liqp.TemplateContext;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
-
 import static liqp.TestUtils.getNode;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
 
 public class LookupNodeTest {
 
@@ -25,7 +28,7 @@ public class LookupNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render(json));
 
             assertThat(rendered, is(test[1]));
@@ -274,7 +277,7 @@ public class LookupNodeTest {
 
         String assigns = "{ \"array\" : [1,2,3,4] }";
 
-        assertThat(Template.parse("array has {{ array.size }} elements").render(assigns), is("array has 4 elements"));
+        assertThat(TemplateParser.DEFAULT.parse("array has {{ array.size }} elements").render(assigns), is("array has 4 elements"));
     }
 
     /*
@@ -288,14 +291,14 @@ public class LookupNodeTest {
 
         String assigns = "{ \"hash\" : { \"a\" : 1, \"b\" : 2, \"c\" : 3, \"d\" : 4 } }";
 
-        assertThat(Template.parse("hash has {{ hash.size }} elements").render(assigns), is("hash has 4 elements"));
+        assertThat(TemplateParser.DEFAULT.parse("hash has {{ hash.size }} elements").render(assigns), is("hash has 4 elements"));
     }
 
     /*
      * https://github.com/bkiers/Liqp/issues/209
      *
      * data = { 'Data' => { '1' => { 'Value' => 'tobi' }} }
-     * @template = Liquid::Template.parse("hi {{Data.1.Value}}")
+     * @template = Liquid::TemplateParser.DEFAULT.parse("hi {{Data.1.Value}}")
      * puts @template.render(data)
      * # hi tobi
      */
@@ -304,7 +307,7 @@ public class LookupNodeTest {
 
         String assigns = "{ \"Data\" : { \"1\" : { \"Value\": \"tobi\" } } }";
 
-        assertThat(Template.parse("hi {{Data.1.Value}}").render(assigns), is("hi tobi"));
+        assertThat(TemplateParser.DEFAULT.parse("hi {{Data.1.Value}}").render(assigns), is("hi tobi"));
     }
 }
 

--- a/src/test/java/liqp/nodes/LtEqNodeTest.java
+++ b/src/test/java/liqp/nodes/LtEqNodeTest.java
@@ -1,12 +1,8 @@
 package liqp.nodes;
 
-import liqp.Template;
-import liqp.TemplateTest;
-import liqp.parser.Inspectable;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
-
-import javax.lang.model.type.NullType;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -16,10 +12,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 
 public class LtEqNodeTest {
 
@@ -37,7 +36,7 @@ public class LtEqNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -55,13 +54,13 @@ public class LtEqNodeTest {
             public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
         };
 
-        String value = Template.parse("{% if a <= a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a <= a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a <= b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a <= b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a <= c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a <= c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a <= d %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a <= d %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
     }
 
@@ -73,11 +72,11 @@ public class LtEqNodeTest {
         data.put("b", new TemplateTest.ComparableBase(9));
         data.put("c", new TemplateTest.ComparableBase(11));
 
-        String value = Template.parse("{% if a <= a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a <= a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a <= b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a <= b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a <= c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a <= c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
     }
 }

--- a/src/test/java/liqp/nodes/LtNodeTest.java
+++ b/src/test/java/liqp/nodes/LtNodeTest.java
@@ -1,10 +1,8 @@
 package liqp.nodes;
 
-import liqp.Template;
-import liqp.TemplateTest;
-import liqp.parser.Inspectable;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -14,9 +12,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.TemplateTest;
+import liqp.parser.Inspectable;
 
 public class LtNodeTest {
 
@@ -34,7 +36,7 @@ public class LtNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -52,13 +54,13 @@ public class LtNodeTest {
             public ZonedDateTime d = ZonedDateTime.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(100), ZoneOffset.systemDefault()), ZoneOffset.systemDefault());
         };
 
-        String value = Template.parse("{% if a < a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a < a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a < b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a < b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a < c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a < c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
-        value = Template.parse("{% if a < d %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a < d %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
     }
     @Test
@@ -69,11 +71,11 @@ public class LtNodeTest {
         data.put("b", new TemplateTest.ComparableBase(9));
         data.put("c", new TemplateTest.ComparableBase(11));
 
-        String value = Template.parse("{% if a < a %}yes{% else %}no{% endif %}").render(data);
+        String value = TemplateParser.DEFAULT.parse("{% if a < a %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a < b %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a < b %}yes{% else %}no{% endif %}").render(data);
         assertEquals("no", value);
-        value = Template.parse("{% if a < c %}yes{% else %}no{% endif %}").render(data);
+        value = TemplateParser.DEFAULT.parse("{% if a < c %}yes{% else %}no{% endif %}").render(data);
         assertEquals("yes", value);
     }
 }

--- a/src/test/java/liqp/nodes/NEqNodeTest.java
+++ b/src/test/java/liqp/nodes/NEqNodeTest.java
@@ -1,11 +1,13 @@
 package liqp.nodes;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class NEqNodeTest {
 
@@ -21,7 +23,7 @@ public class NEqNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/nodes/OrNodeTest.java
+++ b/src/test/java/liqp/nodes/OrNodeTest.java
@@ -1,11 +1,13 @@
 package liqp.nodes;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class OrNodeTest {
 
@@ -23,7 +25,7 @@ public class OrNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/nodes/OutputNodeTest.java
+++ b/src/test/java/liqp/nodes/OutputNodeTest.java
@@ -1,15 +1,17 @@
 package liqp.nodes;
 
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class OutputNodeTest {
 
@@ -23,7 +25,7 @@ public class OutputNodeTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render("{\"X\" : \"mu\"}"));
 
             assertThat(rendered, is(test[1]));
@@ -72,7 +74,7 @@ public class OutputNodeTest {
             String test = "{{" + keyword + "}}";
             String expected = keyword + "_" + Integer.toString(keyword.length());
             String json = "{\"" + keyword + "\" : \"" + expected + "\" }";
-            Template template = Template.parse(test);
+            Template template = TemplateParser.DEFAULT.parse(test);
             String rendered = template.render(json);
 
             assertThat(rendered + "=" + expected, rendered, is(expected));
@@ -95,7 +97,7 @@ public class OutputNodeTest {
             String test = "{{" + keyword[0] + "}}";
             String expected = keyword[1];
             String json = "{\"" + keyword[0] + "\" : \"bad\" }";
-            Template template = Template.parse(test);
+            Template template = TemplateParser.DEFAULT.parse(test);
             String rendered = template.render(json);
 
             String message = test + " --> [" + rendered + "] = [" + expected + "]";
@@ -108,7 +110,7 @@ public class OutputNodeTest {
         // given
 
         // when
-        String res = Template.parse("{{ a | truncate: 13 }}").render(Collections.singletonMap("a", LocalDateTime.parse("2011-12-03T10:15:30")));
+        String res = TemplateParser.DEFAULT.parse("{{ a | truncate: 13 }}").render(Collections.singletonMap("a", LocalDateTime.parse("2011-12-03T10:15:30")));
 
         // then
         assertEquals("2011-12-03...", res);

--- a/src/test/java/liqp/parser/LiquidSupportTest.java
+++ b/src/test/java/liqp/parser/LiquidSupportTest.java
@@ -1,19 +1,21 @@
 package liqp.parser;
 
-import liqp.RenderSettings;
-import liqp.Template;
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import liqp.RenderSettings;
+import liqp.TemplateParser;
+
 public class LiquidSupportTest {
 
-    private static final RenderSettings EAGER_RENDERING = new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build();
+    private static final RenderSettings EAGER_RENDERING_SETTINGS = new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build();
+    private static final TemplateParser EAGER_RENDERING_PARSER = new TemplateParser.Builder().withRenderSettings(EAGER_RENDERING_SETTINGS).build();
 
     // test plan:
     // 1 feature
@@ -58,12 +60,12 @@ public class LiquidSupportTest {
         return data;
     }
     private void assertOldRender(String template, Map<String, Object> data, String expected) {
-        String fooA = Template.parse(template).render(data);
+        String fooA = TemplateParser.DEFAULT.parse(template).render(data);
         assertThat(fooA, is(expected));
     }
 
     private void assertEagerRender(String template, Map<String, Object> data, String expected) {
-        String fooA = Template.parse(template).withRenderSettings(EAGER_RENDERING).render(data);
+        String fooA = EAGER_RENDERING_PARSER.parse(template).render(data);
         assertThat(fooA, is(expected));
     }
     // LookupNode
@@ -179,7 +181,7 @@ public class LiquidSupportTest {
     public void verifyOldBehaviorWorks() {
         Map<String, Object> data = new HashMap<String, Object>();
         data.put("foo", new Foo());
-        String fooA = Template.parse("{{foo.a}}").render(data);
+        String fooA = TemplateParser.DEFAULT.parse("{{foo.a}}").render(data);
 
         assertThat(fooA, is(""));
     }
@@ -188,7 +190,7 @@ public class LiquidSupportTest {
     public void renderMapWithPojosWithNewRenderingSettings() {
         Map<String, Object> data = new HashMap<String, Object>();
         data.put("foo", new Foo());
-        String fooA = Template.parse("{{foo.a}}").withRenderSettings(EAGER_RENDERING).render(data);
+        String fooA = EAGER_RENDERING_PARSER.parse("{{foo.a}}").render(data);
 
         assertThat(fooA, is("A"));
     }
@@ -198,7 +200,7 @@ public class LiquidSupportTest {
         Map<String, Object> data = new HashMap<String, Object>();
         class FooWrapper extends Foo implements Inspectable {}
         data.put("foo", new FooWrapper());
-        String fooA = Template.parse("{{foo.a}}").render(data);
+        String fooA = TemplateParser.DEFAULT.parse("{{foo.a}}").render(data);
 
         assertThat(fooA, is("A"));
     }
@@ -212,7 +214,7 @@ public class LiquidSupportTest {
         in.put("a", inspect);
 
         // when
-        String res = Template.parse("{{a.val}}").render(in);
+        String res = TemplateParser.DEFAULT.parse("{{a.val}}").render(in);
 
         // then
         assertEquals("OK", res);
@@ -224,8 +226,8 @@ public class LiquidSupportTest {
         inspect.setVal("not this");
         Map<String, Object> in = new HashMap<>();
         in.put("a", inspect);
-
-        String fooA = Template.parse("{{a.val}}").withRenderSettings(new RenderSettings.Builder().withEvaluateMode(RenderSettings.EvaluateMode.EAGER).build()).render(in);
+        
+        String fooA = EAGER_RENDERING_PARSER.parse("{{a.val}}").render(in);
 
         assertThat(fooA, is("OK"));
     }

--- a/src/test/java/liqp/parser/ParseTest.java
+++ b/src/test/java/liqp/parser/ParseTest.java
@@ -1,18 +1,19 @@
 package liqp.parser;
 
-import liqp.Template;
-import liqp.exceptions.LiquidException;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import liqp.TemplateParser;
+import liqp.exceptions.LiquidException;
 
 public class ParseTest {
 
     /*
      * def test_error_with_css
      *   text = %| div { font-weight: bold; } |
-     *   template = Template.parse(text)
+     *   template = TemplateParser.DEFAULT.parse(text)
      *
      *   assert_equal text, template.render
      *   assert_equal [String], template.root.nodelist.collect {|i| i.class}
@@ -23,59 +24,59 @@ public class ParseTest {
 
         String text = " div { font-weight: bold; } ";
 
-        assertThat(Template.parse(text).render(), is(text));
+        assertThat(TemplateParser.DEFAULT.parse(text).render(), is(text));
     }
 
     /*
      * def test_raise_on_single_close_bracet
      *   assert_raise(SyntaxError) do
-     *     Template.parse("text {{method} oh nos!")
+     *     TemplateParser.DEFAULT.parse("text {{method} oh nos!")
      *   end
      * end
      */
     @Test(expected=LiquidException.class)
     public void raise_on_single_close_bracetTest() throws Exception {
-        Template.parse("text {{method} oh nos!");
+        TemplateParser.DEFAULT.parse("text {{method} oh nos!");
     }
 
     /*
      * def test_raise_on_label_and_no_close_bracets
      *   assert_raise(SyntaxError) do
-     *     Template.parse("TEST {{ ")
+     *     TemplateParser.DEFAULT.parse("TEST {{ ")
      *   end
      * end
      */
     @Test(expected=LiquidException.class)
     public void raise_on_label_and_no_close_bracetsTest() throws Exception {
-        Template.parse("TEST {{ ");
+        TemplateParser.DEFAULT.parse("TEST {{ ");
     }
 
     /*
      * def test_raise_on_label_and_no_close_bracets_percent
      *   assert_raise(SyntaxError) do
-     *     Template.parse("TEST {% ")
+     *     TemplateParser.DEFAULT.parse("TEST {% ")
      *   end
      * end
      */
     @Test(expected=LiquidException.class)
     public void raise_on_label_and_no_close_bracets_percentTest() throws Exception {
-        Template.parse("TEST {% ");
+        TemplateParser.DEFAULT.parse("TEST {% ");
     }
 
     /*
      * def test_error_on_empty_filter
      *   assert_nothing_raised do
-     *     Template.parse("{{test |a|b|}}")
-     *     Template.parse("{{test}}")
-     *     Template.parse("{{|test|}}")
+     *     TemplateParser.DEFAULT.parse("{{test |a|b|}}")
+     *     TemplateParser.DEFAULT.parse("{{test}}")
+     *     TemplateParser.DEFAULT.parse("{{|test|}}")
      *   end
      * end
      */
     @Test
     public void error_on_empty_filterTest() throws Exception {
-        //Template.parse("{{test |a|b|}}"); // TODO isn't allowed (yet?)
-        Template.parse("{{test}}");
-        //Template.parse("{{|test|}}"); // TODO isn't allowed (yet?)
+        //TemplateParser.DEFAULT.parse("{{test |a|b|}}"); // TODO isn't allowed (yet?)
+        TemplateParser.DEFAULT.parse("{{test}}");
+        //TemplateParser.DEFAULT.parse("{{|test|}}"); // TODO isn't allowed (yet?)
     }
 
     /*
@@ -90,7 +91,7 @@ public class ParseTest {
 
         String assigns = "{\"b\" : \"bar\", \"c\" : \"baz\"}";
         String markup = "a == 'foo' or (b == 'bar' and c == 'baz') or false";
-        assertThat(Template.parse("{% if " + markup + " %} YES {% endif %}").render(assigns), is(" YES "));
+        assertThat(TemplateParser.DEFAULT.parse("{% if " + markup + " %} YES {% endif %}").render(assigns), is(" YES "));
     }
 
     /*
@@ -104,21 +105,21 @@ public class ParseTest {
     @Test
     public void unexpected_characters_silently_eat_logicTest() throws Exception {
 
-        //assertThat(Template.parse("{% if true && false %} YES {% endif %}").render(), is(" YES ")); // TODO isn't allowed (yet?)
+        //assertThat(TemplateParser.DEFAULT.parse("{% if true && false %} YES {% endif %}").render(), is(" YES ")); // TODO isn't allowed (yet?)
 
-        //assertThat(Template.parse("{% if true || false %} YES {% endif %}").render(), is(" YES ")); // TODO isn't allowed (yet?)
+        //assertThat(TemplateParser.DEFAULT.parse("{% if true || false %} YES {% endif %}").render(), is(" YES ")); // TODO isn't allowed (yet?)
     }
 
     @Test
     public void keywords_as_identifier() throws Exception {
 
         assertThat(
-                Template.parse("var2:{{var2}} {%assign var2 = var.comment%} var2:{{var2}}")
+                TemplateParser.DEFAULT.parse("var2:{{var2}} {%assign var2 = var.comment%} var2:{{var2}}")
                         .render(" { \"var\": { \"comment\": \"content\" } } "),
                 is("var2:  var2:content"));
 
         assertThat(
-                Template.parse("var2:{{var2}} {%assign var2 = var.end%} var2:{{var2}}")
+                TemplateParser.DEFAULT.parse("var2:{{var2}} {%assign var2 = var.end%} var2:{{var2}}")
                         .render(" { \"var\": { \"end\": \"content\" } } "),
                 is("var2:  var2:content"));
     }

--- a/src/test/java/liqp/tags/AssignTest.java
+++ b/src/test/java/liqp/tags/AssignTest.java
@@ -1,11 +1,13 @@
 package liqp.tags;
 
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class AssignTest {
 
@@ -19,7 +21,7 @@ public class AssignTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));
@@ -27,11 +29,11 @@ public class AssignTest {
 
         String json = "{\"values\":[\"A\", [\"B1\", \"B2\"], \"C\"]}";
 
-        assertThat(Template.parse("{% assign foo = values %}.{{ foo[1][1] }}.").render(json), is(".B2."));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign foo = values %}.{{ foo[1][1] }}.").render(json), is(".B2."));
 
         json = "{\"values\":[\"A\", {\"bar\":{\"xyz\":[\"B1\", \"ok\"]}}, \"C\"]}";
 
-        assertThat(Template.parse("{% assign foo = values %}.{{ foo[1].bar.xyz[1] }}.").render(json), is(".ok."));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign foo = values %}.{{ foo[1].bar.xyz[1] }}.").render(json), is(".ok."));
     }
 
     /*
@@ -56,16 +58,16 @@ public class AssignTest {
 
         final String[] values = {"foo", "bar", "baz"};
 
-        assertThat(Template.parse("{% assign foo = values %}.{{ foo[0] }}.").render("values", values), is(".foo."));
-        assertThat(Template.parse("{% assign foo = values %}.{{ foo[1] }}.").render("values", values), is(".bar."));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign foo = values %}.{{ foo[0] }}.").render("values", values), is(".foo."));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign foo = values %}.{{ foo[1] }}.").render("values", values), is(".bar."));
 
-        assertThat(Template.parse("{% assign foo = values | split: \",\" %}.{{ foo[1] }}.").render("values", "foo,bar,baz"), is(".bar."));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign foo = values | split: \",\" %}.{{ foo[1] }}.").render("values", "foo,bar,baz"), is(".bar."));
     }
 
     @Test
     public void multipleFiltersTest() {
         // https://github.com/bkiers/Liqp/issues/84
-        assertThat(Template.parse("{% assign v = 1 | minus: 10 | plus: 5 %}{{v}}").render(), is("-4"));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign v = 1 | minus: 10 | plus: 5 %}{{v}}").render(), is("-4"));
     }
 
     /*
@@ -79,7 +81,7 @@ public class AssignTest {
     @Test
     public void hyphenatedVariableTest() throws Exception {
 
-        assertThat(Template.parse("{% assign oh-my = 'godz' %}{{ oh-my }}").render(), is("godz"));
+        assertThat(TemplateParser.DEFAULT.parse("{% assign oh-my = 'godz' %}{{ oh-my }}").render(), is("godz"));
     }
 
     /*
@@ -93,7 +95,7 @@ public class AssignTest {
     public void assignTest() throws Exception {
 
         assertThat(
-                Template.parse("var2:{{var2}} {%assign var2 = var%} var2:{{var2}}")
+                TemplateParser.DEFAULT.parse("var2:{{var2}} {%assign var2 = var%} var2:{{var2}}")
                         .render(" { \"var\" : \"content\" } "),
                 is("var2:  var2:content"));
     }
@@ -108,7 +110,7 @@ public class AssignTest {
     public void hyphenated_assignTest() throws Exception {
 
         assertThat(
-                Template.parse("a-b:{{a-b}} {%assign a-b = 2 %}a-b:{{a-b}}")
+                TemplateParser.DEFAULT.parse("a-b:{{a-b}} {%assign a-b = 2 %}a-b:{{a-b}}")
                         .render(" { \"a-b\" : \"1\" } "),
                 is("a-b:1 a-b:2"));
     }
@@ -123,35 +125,35 @@ public class AssignTest {
     public void assign_with_colon_and_spacesTest() throws Exception {
 
         assertThat(
-                Template.parse("{%assign var2 = var[\"a:b c\"].paged %}var2: {{var2}}")
+                TemplateParser.DEFAULT.parse("{%assign var2 = var[\"a:b c\"].paged %}var2: {{var2}}")
                         .render("{\"var\" : {\"a:b c\" : {\"paged\" : \"1\" }}}"),
                 is("var2: 1"));
     }
 
     /*
      * def test_assign
-     *   assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{{a}}'  ).render
+     *   assert_equal 'variable', Liquid::TemplateParser.DEFAULT.parse( '{% assign a = "variable"%}{{a}}'  ).render
      * end
      */
     @Test
     public void assign2Test() throws Exception {
 
         assertThat(
-                Template.parse("{% assign a = \"variable\"%}{{a}}")
+                TemplateParser.DEFAULT.parse("{% assign a = \"variable\"%}{{a}}")
                         .render(),
                 is("variable"));
     }
 
     /*
      * def test_assign_an_empty_string
-     *   assert_equal '', Liquid::Template.parse( '{% assign a = ""%}{{a}}'  ).render
+     *   assert_equal '', Liquid::TemplateParser.DEFAULT.parse( '{% assign a = ""%}{{a}}'  ).render
      * end
      */
     @Test
     public void assign_an_empty_stringTest() throws Exception {
 
         assertThat(
-                Template.parse("{% assign a = \"\"%}{{a}}")
+                TemplateParser.DEFAULT.parse("{% assign a = \"\"%}{{a}}")
                         .render(),
                 is(""));
     }
@@ -159,14 +161,14 @@ public class AssignTest {
     /*
      * def test_assign_is_global
      *   assert_equal 'variable',
-     *                Liquid::Template.parse( '{%for i in (1..2) %}{% assign a = "variable"%}{% endfor %}{{a}}'  ).render
+     *                Liquid::TemplateParser.DEFAULT.parse( '{%for i in (1..2) %}{% assign a = "variable"%}{% endfor %}{{a}}'  ).render
      * end
      */
     @Test
     public void assign_is_globalTest() throws Exception {
 
         assertThat(
-                Template.parse("{%for i in (1..2) %}{% assign a = \"variable\"%}{% endfor %}{{a}}")
+                TemplateParser.DEFAULT.parse("{%for i in (1..2) %}{% assign a = \"variable\"%}{% endfor %}{{a}}")
                         .render(),
                 is("variable"));
     }

--- a/src/test/java/liqp/tags/DecrementTest.java
+++ b/src/test/java/liqp/tags/DecrementTest.java
@@ -1,11 +1,12 @@
 package liqp.tags;
 
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class DecrementTest {
 
@@ -25,7 +26,7 @@ public class DecrementTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -1,16 +1,12 @@
 package liqp.tags;
 
-import liqp.*;
-import liqp.exceptions.LiquidException;
-import liqp.exceptions.VariableNotExistException;
-import liqp.filters.Filter;
-import liqp.tags.Include;
-import liqp.parser.Flavor;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,9 +16,20 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.isA;
-import static org.junit.Assert.*;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import liqp.ParseSettings;
+import liqp.RenderSettings;
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.exceptions.LiquidException;
+import liqp.exceptions.VariableNotExistException;
+import liqp.filters.Filter;
+import liqp.parser.Flavor;
 
 public class IncludeTest {
 
@@ -47,7 +54,7 @@ public class IncludeTest {
                 "{% assign shape = 'square' %}\n" +
                 "{% include 'color' with 'red' %}";
 
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
 
         String rendered = template.render();
 
@@ -65,7 +72,15 @@ public class IncludeTest {
 
     @Test
     public void testIncludeVariableSyntaxTag() {
-        Template template = Template.parse("{% include {{ tmpl }} %}", jekyll());
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(jekyll()).build();
+        Template template = parser.parse("{% include {{ tmpl }} %}");
+        String res = template.render("{ \"var\" : \"TEST\", \"tmpl\" : \"include_read_var\"}");
+        assertEquals("TEST", res);
+    }
+
+    @Test
+    public void testIncludeVariableSyntaxTagDefaultJekyll() {
+        Template template = Flavor.JEKYLL.defaultParser().parse("{% include {{ tmpl }} %}");
         String res = template.render("{ \"var\" : \"TEST\", \"tmpl\" : \"include_read_var\"}");
         assertEquals("TEST", res);
     }
@@ -73,16 +88,16 @@ public class IncludeTest {
     @Test(expected = LiquidException.class)
     public void renderWithShouldThrowExceptionInJekyll() throws RecognitionException {
 
-        Template template = Template.parse("{% include 'color' with 'red' %}",
-                new ParseSettings.Builder()
-                        .withFlavor(Flavor.JEKYLL)
-                        .build(),
-                new RenderSettings
-                        .Builder()
-                        .withRaiseExceptionsInStrictMode(true)
-                        .withShowExceptionsFromInclude(true)
-                        .build()
-        );
+        TemplateParser parser = new TemplateParser.Builder() //
+                .withParseSettings(jekyll()) //
+                .withRenderSettings( //
+                        new RenderSettings.Builder() //
+                                .withRaiseExceptionsInStrictMode(true) //
+                                .withShowExceptionsFromInclude(true) //
+                                .build()) //
+                .build();
+
+        Template template = parser.parse("{% include 'color' with 'red' %}");
 
         template.render();
 
@@ -91,17 +106,17 @@ public class IncludeTest {
 
     @Test
     public void renderWithShouldWorkInLiquid() throws RecognitionException {
-
-        Template template = Template.parse("{% include 'color' with 'red' %}",
-                new ParseSettings.Builder()
+        TemplateParser parser = new TemplateParser.Builder() //
+                .withParseSettings(new ParseSettings.Builder()
                         .withFlavor(Flavor.LIQUID)
-                        .build(),
-                new RenderSettings
+                        .build())
+                .withRenderSettings(new RenderSettings
                         .Builder()
                         .withRaiseExceptionsInStrictMode(true)
                         .withShowExceptionsFromInclude(true)
-                        .build()
-        );
+                        .build()).build();
+
+        Template template = parser.parse("{% include 'color' with 'red' %}");
 
         String render = template.render();
 
@@ -112,7 +127,7 @@ public class IncludeTest {
     public void renderTestWithIncludeDirectorySpecifiedInContextLiquidFlavor() throws Exception {
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_with_quotes.html");
-        Template template = Template.parse(index);
+        Template template = TemplateParser.DEFAULT.parse(index);
         String result = template.render();
         assertTrue(result.contains("HEADER"));
     }
@@ -121,7 +136,7 @@ public class IncludeTest {
     public void renderTestWithIncludeDirectorySpecifiedInContextJekyllFlavor() throws Exception {
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_without_quotes.html");
-        Template template = Template.parse(index, Flavor.JEKYLL);
+        Template template = Flavor.JEKYLL.defaultParser().parse(index);
         String result = template.render();
         assertTrue(result.contains("HEADER"));
     }
@@ -131,7 +146,7 @@ public class IncludeTest {
     public void renderTestWithIncludeSubdirectorySpecifiedInContextJekyllFlavor() throws Exception {
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_without_quotes_subdirectory.html");
-        Template template = Template.parse(index, Flavor.JEKYLL);
+        Template template = Flavor.JEKYLL.defaultParser().parse(index);
         String result = template.render();
         assertTrue(result.contains("FOOTER"));
     }
@@ -139,7 +154,7 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeDirectorySpecifiedInJekyllFlavor() throws Exception {
         File index = new File("src/test/jekyll/index_without_quotes.html");
-        Template template = Template.parse(index, Flavor.JEKYLL);
+        Template template = Flavor.JEKYLL.defaultParser().parse(index);
         String result = template.render();
         assertTrue(result.contains("HEADER"));
     }
@@ -147,7 +162,7 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeDirectorySpecifiedInLiquidFlavor() throws Exception {
         File index = new File("src/test/jekyll/index_with_quotes.html");
-        Template template = Template.parse(index, Flavor.LIQUID);
+        Template template = liquidParser().parse(index);
         String result = template.render();
         assertTrue(result.contains("HEADER"));
     }
@@ -156,20 +171,20 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeSubdirectorySpecifiedInJekyllFlavor() throws Exception {
         File index = new File("src/test/jekyll/index_without_quotes_subdirectory.html");
-        Template template = Template.parse(index, Flavor.JEKYLL);
+        Template template = jekyllParser().parse(index);
         String result = template.render();
         assertTrue(result.contains("FOOTER"));
     }
 
     @Test
     public void renderTestWithIncludeSubdirectorySpecifiedInLiquidFlavorWithStrictVariables() throws Exception {
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(Flavor.LIQUID
+                .defaultParseSettings()).withRenderSettings(new RenderSettings.Builder()
+                        .withStrictVariables(true).withShowExceptionsFromInclude(true).build()).build();;
 
         String expected = "Sample Footer";
         File index = new File("src/test/jekyll/index_with_variables.html");
-        Template template = Template.parse(
-            index,
-            new ParseSettings.Builder().withFlavor(Flavor.LIQUID).build(),
-            new RenderSettings.Builder().withStrictVariables(true).withShowExceptionsFromInclude(true).build());
+        Template template = parser.parse(index);
         Map<String, Object> variables = new HashMap<>();
         variables.put("FOOTERTEXT", expected);
         String result = template.render(variables);
@@ -183,10 +198,14 @@ public class IncludeTest {
         thrown.expectCause(isA(VariableNotExistException.class));
 
         File index = new File("src/test/jekyll/index_with_variables.html");
-        Template template = Template.parse(
-            index,
-            new ParseSettings.Builder().withFlavor(Flavor.LIQUID).build(),
-            new RenderSettings.Builder().withStrictVariables(true).withShowExceptionsFromInclude(true).build());
+        TemplateParser parser = new TemplateParser.Builder() //
+            .withParseSettings(Flavor.LIQUID.defaultParseSettings()) //
+            .withRenderSettings(new RenderSettings.Builder() //
+                    .withStrictVariables(true) //
+                    .withShowExceptionsFromInclude(true) //
+                    .build()) //
+            .build();
+        Template template = parser.parse(index);
         template.render();
     }
 
@@ -194,7 +213,7 @@ public class IncludeTest {
     @Test
     public void renderTestWithIncludeSubdirectorySpecifiedInLiquidFlavor() throws Exception {
         File index = new File("src/test/jekyll/index_with_quotes_subdirectory.html");
-        Template template = Template.parse(index, Flavor.LIQUID);
+        Template template = Flavor.LIQUID.defaultParser().parse(index);
         String result = template.render();
         assertTrue(result.contains("FOOTER"));
     }
@@ -205,8 +224,7 @@ public class IncludeTest {
 
         String source = "{% assign variable = 'header.html' %}{% include {{variable}} %}";
 
-        ParseSettings settings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
-        String rendered = Template.parse(source, settings).render();
+        String rendered = Flavor.JEKYLL.defaultParser().parse(source).render();
 
         assertTrue(rendered.contains("HEADER"));
     }
@@ -214,20 +232,17 @@ public class IncludeTest {
     // https://github.com/bkiers/Liqp/issues/75
     @Test(expected = RuntimeException.class)
     public void expressionInIncludeTagLiquidThrowsException() {
-
         String source = "{% assign variable = 'header.html' %}{% include {{variable}} %}";
 
-        ParseSettings settings = new ParseSettings.Builder().withFlavor(Flavor.LIQUID).build();
-        Template.parse(source, settings).render();
+        Flavor.LIQUID.defaultParser().parse(source).render();
     }
 
     // https://github.com/bkiers/Liqp/issues/75
     @Test(expected = RuntimeException.class)
     public void expressionInIncludeTagDefaultFlavorThrowsException() {
-
         String source = "{% assign variable = 'header.html' %}{% include {{variable}} %}";
 
-        Template.parse(source).render();
+        TemplateParser.DEFAULT.parse(source).render();
     }
 
     @Test
@@ -235,7 +250,7 @@ public class IncludeTest {
         // given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_without_quotes.html");
-        Template template = Template.parse(index, new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build());
+        Template template = Flavor.JEKYLL.defaultParser().parse(index);
         Map<String, Object> data = new HashMap<String, Object>();
         data.put(Include.INCLUDES_DIRECTORY_KEY, new File(new File("").getAbsolutePath(), "src/test/jekyll/alternative_includes"));
 
@@ -251,7 +266,7 @@ public class IncludeTest {
         // given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_without_quotes.html");
-        Template template = Template.parse(index, new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build());
+        Template template = Flavor.JEKYLL.defaultParser().parse(index);
         Map<String, Object> data = new HashMap<String, Object>();
         String alternativePath = new File(new File("").getAbsolutePath(), "src/test/jekyll/alternative_includes").getAbsolutePath();
         data.put(Include.INCLUDES_DIRECTORY_KEY, alternativePath);
@@ -267,7 +282,7 @@ public class IncludeTest {
         // given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_without_quotes.html");
-        Template template = Template.parse(index, new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build());
+        Template template = Flavor.JEKYLL.defaultParser().parse(index);
         Map<String, Object> data = new HashMap<String, Object>();
         String alternativePath = new File(new File("").getAbsolutePath(), "src/test/jekyll/alternative_includes").getAbsolutePath();
         data.put(Include.INCLUDES_DIRECTORY_KEY, Paths.get(alternativePath));
@@ -284,10 +299,30 @@ public class IncludeTest {
         //given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_with_errored_include.html");
+        ParseSettings parseSettings = Flavor.JEKYLL.defaultParseSettings();
+        RenderSettings renderSettings = new RenderSettings.Builder().withShowExceptionsFromInclude(false).build();
+       
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(parseSettings)
+                .withRenderSettings(renderSettings).build();
+        
+        Template template = parser.parse(index);
+
+        // when
+        String result = template.render();
+
+        // then
+        assertFalse(result.contains("THE_ERROR"));
+    }
+
+    @Test
+    public void errorInIncludeCauseIgnoreErrorWhenNoExceptionsFromIncludeLegacy() throws IOException {
+        //given
+        File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
+        File index = new File(jekyll, "index_with_errored_include.html");
         ParseSettings parseSettings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
         RenderSettings renderSettings = new RenderSettings.Builder().withShowExceptionsFromInclude(false).build();
+        @SuppressWarnings("deprecation")
         Template template = Template.parse(index, parseSettings).withRenderSettings(renderSettings);
-
 
         // when
         String result = template.render();
@@ -301,10 +336,13 @@ public class IncludeTest {
         //given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_with_errored_include.html");
-        ParseSettings parseSettings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
+        ParseSettings parseSettings = Flavor.JEKYLL.defaultParseSettings();;
         RenderSettings renderSettings = new RenderSettings.Builder().withShowExceptionsFromInclude(true).build();
-        Template template = Template.parse(index, parseSettings).withRenderSettings(renderSettings);
+        
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(parseSettings)
+                .withRenderSettings(renderSettings).build();
 
+        Template template = parser.parse(index);
 
         // when
         template.render();
@@ -316,6 +354,29 @@ public class IncludeTest {
     @Test
     public void errorInIncludeCauseMissingIncludeWithCustomRenderingAndFixedError() throws IOException {
         //given
+        File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
+        File index = new File(jekyll, "index_with_errored_include.html");
+
+        ParseSettings parseSettings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).with(
+                new Filter("unknown_and_for_sure_enexist_filter") {
+                }).build();
+        
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(parseSettings).build();
+
+        Template template = parser.parse(index);
+
+        // when
+        String result = template.render();
+
+        // then
+        assertTrue(result.contains("THE_ERROR"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void errorInIncludeCauseMissingIncludeWithCustomRenderingAndFixedErrorLegacy1()
+            throws IOException {
+        // given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
         File index = new File(jekyll, "index_with_errored_include.html");
         ParseSettings parseSettings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
@@ -331,14 +392,36 @@ public class IncludeTest {
         assertTrue(result.contains("THE_ERROR"));
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
+    public void errorInIncludeCauseMissingIncludeWithCustomRenderingAndFixedErrorLegacy2()
+            throws IOException {
+        // given
+        File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
+        File index = new File(jekyll, "index_with_errored_include.html");
+        ParseSettings parseSettings = new ParseSettings.Builder().withFlavor(Flavor.JEKYLL) //
+                .with(new Filter("unknown_and_for_sure_enexist_filter") {
+                }).build();
+        Template template = Template.parse(index, parseSettings);
+
+        // when
+        String result = template.render();
+
+        // then
+        assertTrue(result.contains("THE_ERROR"));
+    }
+
     @Test
     public void testIncludeMustSeeVariablesFromOuterScopeInLiquid() throws IOException {
         // liquid
 
         String templateText = "{% assign var = 'variable' %}{% include 'include_read_var' %}";
 
-        Template template = Template.parse(templateText, liquid())
-                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(liquid())
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+
+        Template template = parser.parse(templateText);
 
         assertEquals("variable", template.render());
 
@@ -350,8 +433,11 @@ public class IncludeTest {
         // liquid
         String templateText = "{% include 'include_create_new_var' %}{{ incl_var }}";
 
-        Template template = Template.parse(templateText, liquid())
-                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(liquid())
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+        
+        Template template = parser.parse(templateText);
 
         assertEquals("incl_var", template.render());
     }
@@ -362,8 +448,11 @@ public class IncludeTest {
 
         String templateText = "{% assign var = 4 %}{% include 'include_decrement_var_not_interfere' %} ! {{ var }}";
 
-        Template template = Template.parse(templateText, liquid())
-                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(liquid())
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+        
+        Template template = parser.parse(templateText);
 
         assertEquals("-1 ! 4", template.render());
     }
@@ -373,10 +462,13 @@ public class IncludeTest {
     public void testIncludeMustSeeVariablesFromOuterScopeInJekyll() throws IOException {
         // jekyll
 
-        Template template = Template.parse("" +
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(jekyll())
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+
+        Template template = parser.parse("" +
                 "{% assign var = 'variable' %}" +
-                "{% include include_read_var.liquid %}", jekyll())
-                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build());
+                "{% include include_read_var.liquid %}");
 
         assertEquals("variable", template.render());
 
@@ -387,14 +479,17 @@ public class IncludeTest {
     @Test
     public void testIncludesMissingValues() throws IOException {
         // given
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(jekyll())
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+
         // when
-        String rendered = Template.parse( ""
+        String rendered = parser.parse( ""
                 + "{% assign list = \"1,2\" | split: \",\" %}"
                 + "{% for n in list %}"
                 +     "{% assign inner = n %}"
                 +     "{% include include_iterations_variables.liquid %}"
-                + "{% endfor %}", jekyll())
-                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build())
+                + "{% endfor %}")
                 .render();
 
 
@@ -412,7 +507,7 @@ public class IncludeTest {
     public void testRewriteValuesFromInclude() {
         // given
         // when
-        String rendered = Template.parse("{% assign val = 'OUTER'%}{% include 'include_var' %}{{val}}").render();
+        String rendered = TemplateParser.DEFAULT.parse("{% assign val = 'OUTER'%}{% include 'include_var' %}{{val}}").render();
 
         // then
         assertEquals("INNER", rendered);
@@ -420,12 +515,16 @@ public class IncludeTest {
 
     @Test
     public void testDecrementIncrementMustContinueThoughInclude() {
-        String rendered = Template.parse(""
+        TemplateParser parser = new TemplateParser.Builder()
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+        
+        String rendered = parser.parse(""
                 + "[{% decrement var1 %},{% increment var2 %}]"
                 + "[{% include 'include_decrement_var' %}]"
                 + "[{% decrement var1 %},{% increment var2 %}]"
                 + "[{{ var1 }}, {{ var2 }}]"
-                + "").withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build())
+                + "")
                 .render();
 
         assertEquals("[-1,0][-2,1][-3,2][-3, 3]", rendered);
@@ -433,20 +532,23 @@ public class IncludeTest {
 
     @Test
     public void testCycleMustContinueThoughInclude() throws IOException {
-        String rendered = Template.parse(""
+        TemplateParser parser = new TemplateParser.Builder()
+                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true)
+                        .build()).build();
+        
+        String rendered = parser.parse(""
                 + "{% cycle 1,2,3,4 %}"
                 + "{% assign list = \"1\" | split: \",\" %}{% for n in list %}{% cycle 1,2,3,4 %}{% endfor %}"
                 + "{% cycle 1,2,3,4 %}"
                 + "{% include 'include_cycle' %}"
                 + "")
-                .withRenderSettings(new RenderSettings.Builder().withShowExceptionsFromInclude(true).build())
                 .render();
         assertEquals("1234", rendered);
     }
 
     @Test
     public void testIfchangedThoughInclude() throws IOException {
-        String rendered = Template.parse(""
+        String rendered = TemplateParser.DEFAULT.parse(""
                 + "{% ifchanged %}1{% endifchanged %}"
                 + "{% ifchanged %}2{% endifchanged %}"
                 + "{% include 'include_ifchanged' %}"
@@ -459,18 +561,25 @@ public class IncludeTest {
     public void testOwnScopeInInclude() throws IOException {
 
         // when
-        String rendered = Template.parse("{% for item in (1..2) %}{% include 'include_iteration' %}{% endfor %}{{ item }}").render();
+        String rendered = TemplateParser.DEFAULT.parse("{% for item in (1..2) %}{% include 'include_iteration' %}{% endfor %}{{ item }}").render();
 
         // then
         assertEquals("1212", rendered);
     }
 
     public ParseSettings jekyll() {
-        return new ParseSettings.Builder().withFlavor(Flavor.JEKYLL).build();
+        return Flavor.JEKYLL.defaultParseSettings();
     }
 
     public ParseSettings liquid() {
-        return new ParseSettings.Builder().withFlavor(Flavor.LIQUID).build();
+        return Flavor.LIQUID.defaultParseSettings();
+    }
+    
+    public TemplateParser jekyllParser() {
+        return new TemplateParser.Builder().withParseSettings(jekyll()).build();
     }
 
+    public TemplateParser liquidParser() {
+        return new TemplateParser.Builder().withParseSettings(liquid()).build();
+    }
 }

--- a/src/test/java/liqp/tags/IncrementTest.java
+++ b/src/test/java/liqp/tags/IncrementTest.java
@@ -1,11 +1,12 @@
 package liqp.tags;
 
-import liqp.Template;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class IncrementTest {
 
@@ -35,7 +36,7 @@ public class IncrementTest {
 
         for (String[] test : tests) {
 
-            Template template = Template.parse(test[0]);
+            Template template = TemplateParser.DEFAULT.parse(test[0]);
             String rendered = String.valueOf(template.render());
 
             assertThat(rendered, is(test[1]));

--- a/src/test/java/liqp/tags/WhitespaceControlTest.java
+++ b/src/test/java/liqp/tags/WhitespaceControlTest.java
@@ -1,12 +1,14 @@
 package liqp.tags;
 
-import liqp.ParseSettings;
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.ParseSettings;
+import liqp.Template;
+import liqp.TemplateParser;
 
 // All output in this test class is tested against Ruby 2.3.1 and Liquid 4.0.0
 public class WhitespaceControlTest {
@@ -15,7 +17,7 @@ public class WhitespaceControlTest {
     public void noStrip() throws RecognitionException {
 
         String source = "a  \n  {% assign letter = 'b' %}  \n{{ letter }}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\n....\nb\n..c"));
@@ -25,7 +27,7 @@ public class WhitespaceControlTest {
     public void oneLhsStrip() throws RecognitionException {
 
         String source = "a  \n  {%- assign letter = 'b' %}  \n{{ letter }}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\nb\n..c"));
@@ -35,7 +37,7 @@ public class WhitespaceControlTest {
     public void oneRhsStrip() throws RecognitionException {
 
         String source = "a  \n  {% assign letter = 'b' -%}  \n{{ letter }}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\n..b\n..c"));
@@ -45,7 +47,7 @@ public class WhitespaceControlTest {
     public void oneBothStrip() throws RecognitionException {
 
         String source = "a  \n  {%- assign letter = 'b' -%}  \n{{ letter }}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("ab\n..c"));
@@ -55,7 +57,7 @@ public class WhitespaceControlTest {
     public void twoLhsStrip() throws RecognitionException {
 
         String source = "a  \n  {%- assign letter = 'b' %}  \n{{- letter }}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("ab\n..c"));
@@ -65,7 +67,7 @@ public class WhitespaceControlTest {
     public void twoRhsStrip() throws RecognitionException {
 
         String source = "a  \n  {% assign letter = 'b' -%}  \n{{ letter -}}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\n..bc"));
@@ -75,7 +77,7 @@ public class WhitespaceControlTest {
     public void allStrip() throws RecognitionException {
 
         String source = "a  \n  {%- assign letter = 'b' -%}  \n{{- letter -}}\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("abc"));
@@ -86,7 +88,8 @@ public class WhitespaceControlTest {
 
         String source = "a  \n  {% assign letter = 'b' %}  \n{{ letter }}\n  c";
         ParseSettings settings = new ParseSettings.Builder().withStripSpaceAroundTags(true).build();
-        Template template = Template.parse(source, settings);
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(settings).build();
+        Template template = parser.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("abc"));

--- a/src/test/java/liqp/tags/WhitespaceWindowsControlTest.java
+++ b/src/test/java/liqp/tags/WhitespaceWindowsControlTest.java
@@ -1,12 +1,14 @@
 package liqp.tags;
 
-import liqp.ParseSettings;
-import liqp.Template;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.ParseSettings;
+import liqp.Template;
+import liqp.TemplateParser;
 
 public class WhitespaceWindowsControlTest {
 
@@ -14,7 +16,7 @@ public class WhitespaceWindowsControlTest {
     public void noStrip() throws RecognitionException {
 
         String source = "a  \r\n  {% assign letter = 'b' %}  \r\n{{ letter }}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\r\n....\r\nb\r\n..c"));
@@ -24,7 +26,7 @@ public class WhitespaceWindowsControlTest {
     public void oneLhsStrip() throws RecognitionException {
 
         String source = "a  \r\n  {%- assign letter = 'b' %}  \r\n{{ letter }}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\r\nb\r\n..c"));
@@ -34,7 +36,7 @@ public class WhitespaceWindowsControlTest {
     public void oneRhsStrip() throws RecognitionException {
 
         String source = "a  \r\n  {% assign letter = 'b' -%}  \r\n{{ letter }}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\r\n..b\r\n..c"));
@@ -44,7 +46,7 @@ public class WhitespaceWindowsControlTest {
     public void oneBothStrip() throws RecognitionException {
 
         String source = "a  \r\n  {%- assign letter = 'b' -%}  \r\n{{ letter }}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("ab\r\n..c"));
@@ -54,7 +56,7 @@ public class WhitespaceWindowsControlTest {
     public void twoLhsStrip() throws RecognitionException {
 
         String source = "a  \r\n  {%- assign letter = 'b' %}  \r\n{{- letter }}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("ab\r\n..c"));
@@ -64,7 +66,7 @@ public class WhitespaceWindowsControlTest {
     public void twoRhsStrip() throws RecognitionException {
 
         String source = "a  \r\n  {% assign letter = 'b' -%}  \r\n{{ letter -}}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("a..\r\n..bc"));
@@ -74,7 +76,7 @@ public class WhitespaceWindowsControlTest {
     public void allStrip() throws RecognitionException {
 
         String source = "a  \r\n  {%- assign letter = 'b' -%}  \r\n{{- letter -}}\r\n  c";
-        Template template = Template.parse(source);
+        Template template = TemplateParser.DEFAULT.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("abc"));
@@ -85,7 +87,10 @@ public class WhitespaceWindowsControlTest {
 
         String source = "a  \r\n  {% assign letter = 'b' %}  \r\n{{ letter }}\r\n  c";
         ParseSettings settings = new ParseSettings.Builder().withStripSpaceAroundTags(true).build();
-        Template template = Template.parse(source, settings);
+        
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(settings).build();
+        
+        Template template = parser.parse(source);
         String rendered = String.valueOf(template.render().replace(' ', '.'));
 
         assertThat(rendered, is("abc"));


### PR DESCRIPTION
Currently, there are several places in the API that may have unsafe
side-effects on otherwise unrelated code that shares Liqp running in the
same VM. This is due to global scope that allows modifications around
Insertions and Filters, which are stored as static HashMaps shared
across all callers.

In the worst case this could be seen as a security issue because
unrelated code may interfere and override a certain insertion (tag or
block), leading to information disclosure or data manipulation.

The bug may also just trigger a ConcurrentModificationException when
these modifications occur at an inopportune time.

This patch introduces a clean solution while providing backwards
compatibility for existing code. A new API class, TemplateParser, is
introduced, combining all settings-related configurations in one
immutable place.

Insertions and Filters are now maintained in immutable data structures,
and adding them via the global methods will not affect an existing
TemplateParser instance at all. In the previous cde, these were copied
multiple times from Lists to HashMaps during Template construction,
which is now also no longer necessary.

The Flavor enum is enhanced in such way that it can be used to quickly
access TemplateParsers/ParserSettings with default settings.

The old Template API is marked with @Deprecated statments, encouraging
users to adapt the new one.
