### PR TITLE
[240] Accept dates without time

### DIFF
--- a/src/main/java/liqp/filters/date/Parser.java
+++ b/src/main/java/liqp/filters/date/Parser.java
@@ -46,6 +46,8 @@ public class Parser {
         datePatterns.add("yyyy-MM-dd HH:mm:ss z");
         datePatterns.add("yyyy-MM-dd'T'HH:mm:ss z");
         datePatterns.add("EEE MMM dd hh:mm:ss yyyy");
+        datePatterns.add("yyyy-MM-dd");
+        datePatterns.add("dd-MM-yyyy");
     }
 
     public static ZonedDateTime parse(String str, Locale locale, ZoneId defaultZone) {

--- a/src/test/java/liqp/filters/DateTest.java
+++ b/src/test/java/liqp/filters/DateTest.java
@@ -15,6 +15,7 @@ import liqp.TemplateContext;
 import liqp.filters.date.CustomDateFormatSupport;
 import liqp.parser.Flavor;
 import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import ua.co.k.strftime.formatters.HybridFormat;
@@ -210,5 +211,12 @@ public class DateTest {
 
         String result = t.render(values);
         assertEquals("Space: 2020 | T: 2020", result);
+    }
+
+    @Test
+    public void test240() {
+        assertEquals("10-13", Template.parse("{{ \"2022-10-13 12:06:04\" | date: \"%m-%e\" }}").render());
+        assertEquals("10-13", Template.parse("{{ \"2022-10-13\" | date: \"%m-%e\" }}").render());
+        assertEquals("10-13", Template.parse("{{ \"13-10-2022\" | date: \"%m-%e\" }}").render());
     }
 }


### PR DESCRIPTION
Ruby accepts dates without time:

```ruby
require 'liquid'

tests = [
  '{{ "2022-10-13 12:06:04" | date: "%m-%e" }}',
  '{{ "2022-10-13" | date: "%m-%e" }}',
  '{{ "13-10-2022" | date: "%m-%e" }}'
]

tests.each { |test|
  @template = Liquid::Template.parse(test)
  puts @template.render
}
```

results in:

```
10-13
10-13
10-13
```

With this change, Liqp produces the same output.

Fixes #240
