### PR TITLE
Split: Splitting empty string should yield an empty array

### DIFF
--- a/src/main/java/liqp/filters/Split.java
+++ b/src/main/java/liqp/filters/Split.java
@@ -17,9 +17,14 @@ public class Split extends Filter {
     public Object apply(Object value, TemplateContext context, Object... params) {
 
         String original = super.asString(value, context);
+        if (original.isEmpty()) {
+            return new String[0];
+        }
 
         String delimiter = super.asString(super.get(0, params), context);
 
-        return original.split("(?<!^)" + Pattern.quote(delimiter));
+        String[] val = original.split("(?<!^)" + Pattern.quote(delimiter));
+
+        return val;
     }
 }

--- a/src/test/java/liqp/filters/SplitTest.java
+++ b/src/test/java/liqp/filters/SplitTest.java
@@ -22,6 +22,9 @@ public class SplitTest {
                 {"{{ 'a-b-c' | split:'' }}", "a-b-c"},
                 {"{{ 'a-b-c' | split:'?' }}", "a-b-c"},
                 {"{{ 'a-b-c' | split:nil }}", "a-b-c"},
+                {"{{ '' | split:'-' }}", ""},
+                {"{{ '' | split: '' }}", ""},
+                {"{% assign items = \"\" | split: \"\" %}{% for item in items %}FAIL{{ item }}{% endfor %}", ""},
         };
 
         for (String[] test : tests) {


### PR DESCRIPTION
Currently, splitting an empty string results in an array of length 1 with an empty string.