### PR TITLE
Add Jekyll-specific "pop", "shift", "unshift" filter;  improve "push"

### DIFF
--- a/src/main/java/liqp/filters/Filters.java
+++ b/src/main/java/liqp/filters/Filters.java
@@ -72,8 +72,11 @@ public final class Filters {
 
     static Filters JEKYLL_EXTRA_FILTERS = Filters.of( //
             new Normalize_Whitespace(), //
+            new Pop(), //
             new Push(), //
             new Relative_Url(), //
+            new Shift(), //
+            new Unshift(), //
             new Where_Exp() //
     );
 

--- a/src/main/java/liqp/filters/Pop.java
+++ b/src/main/java/liqp/filters/Pop.java
@@ -1,0 +1,50 @@
+package liqp.filters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import liqp.TemplateContext;
+
+/**
+ * Jekyll-specific filter for array manipulation: Return a new array with the original array's last item
+ * removed. If the original value is not an array, the value is returned as-is.
+ * 
+ * @author Christian Kohlschütter
+ * @see <a href="https://jekyllrb.com/docs/liquid/filters/">Jekyll Liquid Filters</a>
+ */
+public class Pop extends Filter {
+
+    @Override
+    public Object apply(Object value, TemplateContext context, Object... params) {
+        if (!super.isArray(value)) {
+            return value;
+        }
+
+        int numPop;
+        switch (params.length) {
+            case 0:
+                numPop = 1;
+                break;
+            case 1:
+                numPop = asNumber(params[0]).intValue();
+                if (numPop < 0) {
+                    throw new RuntimeException("negative pop value");
+                }
+                break;
+            default:
+                throw new RuntimeException("pop supports up to 1 parameter");
+        }
+
+        List<?> list = asList(value, context);
+        int remainingSize = list.size() - numPop;
+
+        if (remainingSize <= 0) {
+            return Collections.emptyList();
+        } else {
+            list = new ArrayList<>(list.subList(0, remainingSize));
+        }
+
+        return list;
+    }
+}

--- a/src/main/java/liqp/filters/Shift.java
+++ b/src/main/java/liqp/filters/Shift.java
@@ -1,0 +1,48 @@
+package liqp.filters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import liqp.TemplateContext;
+
+/**
+ * Jekyll-specific filter for array manipulation: Return a new array with the original array's first item
+ * removed. If the original value is not an array, the value is returned as-is.
+ * 
+ * @author Christian Kohlschütter
+ * @see <a href="https://jekyllrb.com/docs/liquid/filters/">Jekyll Liquid Filters</a>
+ */
+public class Shift extends Filter {
+
+    @Override
+    public Object apply(Object value, TemplateContext context, Object... params) {
+        if (!super.isArray(value)) {
+            return value;
+        }
+
+        int shiftIndex;
+        switch (params.length) {
+            case 0:
+                shiftIndex = 1;
+                break;
+            case 1:
+                shiftIndex = asNumber(params[0]).intValue();
+                if (shiftIndex < 0) {
+                    throw new RuntimeException("negative shift value");
+                }
+                break;
+            default:
+                throw new RuntimeException("shift supports up to 1 parameter");
+        }
+
+        List<?> list = asList(value, context);
+        int size = list.size();
+        if (shiftIndex >= size) {
+            return Collections.emptyList();
+        }
+        list = new ArrayList<>(list.subList(shiftIndex, size));
+
+        return list;
+    }
+}

--- a/src/main/java/liqp/filters/Unshift.java
+++ b/src/main/java/liqp/filters/Unshift.java
@@ -7,12 +7,12 @@ import liqp.TemplateContext;
 
 /**
  * Jekyll-specific filter for array manipulation: Return a new array with the given item added to the
- * end.  If the filtered value is not an array, it is returned unmodified.
+ * beginning. If the filtered value is not an array, it is returned unmodified.
  * 
  * @author Christian Kohlschütter
  * @see <a href="https://jekyllrb.com/docs/liquid/filters/">Jekyll Liquid Filters</a>
  */
-public class Push extends Filter {
+public class Unshift extends Filter {
 
     @Override
     public Object apply(Object value, TemplateContext context, Object... params) {
@@ -27,8 +27,8 @@ public class Push extends Filter {
         List<?> valueList = asList(value, context);
         List<?> paramList = asList(params, context);
         List<? super Object> list = new ArrayList<>(valueList.size() + paramList.size());
-        list.addAll(valueList);
         list.addAll(paramList);
+        list.addAll(valueList);
 
         return list;
     }

--- a/src/test/java/liqp/filters/PopTest.java
+++ b/src/test/java/liqp/filters/PopTest.java
@@ -1,0 +1,81 @@
+package liqp.filters;
+
+import static liqp.TestUtils.assertPatternInvalid;
+import static liqp.TestUtils.assertPatternResultEquals;
+
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.TemplateParser;
+
+public class PopTest {
+    @Test
+    public void testSimple() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "-foo1",
+            "{% assign items = 'foo,bar' | split: ',' | pop %}" +
+                "{% for item in items %}-{{ item }}{% endfor %}{{ items.size }}");
+    }
+
+    @Test
+    public void testEmpty() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "0",
+            "{% assign items = '' | split: ',' | pop %}{% for item in items %}-{{ item }}{% endfor %}{{ items.size }}");
+    }
+
+    @Test
+    public void testString() throws RecognitionException {
+        assertPatternResultEquals("pop does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | pop %}-{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals("pop does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | pop: 0 %}-{{ item }}{{ item.size }}");
+        assertPatternResultEquals("pop does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | pop: 1 %}-{{ item }}{{ item.size }}");
+        assertPatternResultEquals("pop does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | pop: 2 %}-{{ item }}{{ item.size }}");
+    }
+
+    @Test
+    public void testHelloWorldSplitSpace() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "-Hello1",
+            "{% assign item = 'Hello World' | split: ' ' | pop %}-{{ item }}{{ item.size }}");
+    }
+
+    @Test
+    public void testPopValues() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "HelloWorld2",
+            "{% assign item = 'Hello World' | split: ' ' | pop: 0 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "Hello1",
+            "{% assign item = 'Hello World' | split: ' ' | pop: 1 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "0",
+            "{% assign item = 'Hello World' | split: ' ' | pop: 2 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals("pop values larger than the array result in an empty one",
+            TemplateParser.DEFAULT_JEKYLL, "0",
+            "{% assign item = 'Hello World' | split: ' ' | pop: 3 %}{{ item }}{{ item.size }}");
+
+        assertPatternInvalid("negative pop values are not allowed", TemplateParser.DEFAULT_JEKYLL,
+            "{% assign item = 'Hello World' | split: ' ' | pop: -1 %}{{ item }}{{ item.size }}");
+    }
+
+    @Test
+    public void testHelloWorldSplitZeroLengthString() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "Hello Worl10",
+            "{% assign item = 'Hello World' | split: '' | pop %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "Hello World11",
+            "{% assign item = 'Hello World' | split: '' | pop: 0 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "Hello Worl10",
+            "{% assign item = 'Hello World' | split: '' | pop: 1 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "Hello Wor9",
+            "{% assign item = 'Hello World' | split: '' | pop: 2 %}{{ item }}{{ item.size }}");
+    }
+}

--- a/src/test/java/liqp/filters/ShiftTest.java
+++ b/src/test/java/liqp/filters/ShiftTest.java
@@ -1,0 +1,81 @@
+package liqp.filters;
+
+import static liqp.TestUtils.assertPatternInvalid;
+import static liqp.TestUtils.assertPatternResultEquals;
+
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import liqp.TemplateParser;
+
+public class ShiftTest {
+    @Test
+    public void testSimple() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "-bar1",
+            "{% assign items = 'foo,bar' | split: ',' | shift %}" +
+                "{% for item in items %}-{{ item }}{% endfor %}{{ items.size }}");
+    }
+
+    @Test
+    public void testEmpty() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "0",
+            "{% assign items = '' | split: ',' | shift %}{% for item in items %}-{{ item }}{% endfor %}{{ items.size }}");
+    }
+
+    @Test
+    public void testString() throws RecognitionException {
+        assertPatternResultEquals("shift does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | shift %}-{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals("shift does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | shift: 0 %}-{{ item }}{{ item.size }}");
+        assertPatternResultEquals("shift does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | shift: 1 %}-{{ item }}{{ item.size }}");
+        assertPatternResultEquals("shift does not return an array when the original item isn't one",
+            TemplateParser.DEFAULT_JEKYLL, "-Hello World11",
+            "{% assign item = 'Hello World' | shift: 2 %}-{{ item }}{{ item.size }}");
+    }
+
+    @Test
+    public void testHelloWorldSplitSpace() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "-World1",
+            "{% assign item = 'Hello World' | split: ' ' | shift %}-{{ item }}{{ item.size }}");
+    }
+
+    @Test
+    public void testShiftValues() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "HelloWorld2",
+            "{% assign item = 'Hello World' | split: ' ' | shift: 0 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "World1",
+            "{% assign item = 'Hello World' | split: ' ' | shift: 1 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "0",
+            "{% assign item = 'Hello World' | split: ' ' | shift: 2 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals("shift values larger than the array result in an empty one",
+            TemplateParser.DEFAULT_JEKYLL, "0",
+            "{% assign item = 'Hello World' | split: ' ' | shift: 3 %}{{ item }}{{ item.size }}");
+
+        assertPatternInvalid("negative shift values are not allowed", TemplateParser.DEFAULT_JEKYLL,
+            "{% assign item = 'Hello World' | split: ' ' | shift: -1 %}{{ item }}{{ item.size }}");
+    }
+
+    @Test
+    public void testHelloWorldSplitZeroLengthString() throws RecognitionException {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "ello World10",
+            "{% assign item = 'Hello World' | split: '' | shift %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "Hello World11",
+            "{% assign item = 'Hello World' | split: '' | shift: 0 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "ello World10",
+            "{% assign item = 'Hello World' | split: '' | shift: 1 %}{{ item }}{{ item.size }}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "llo World9",
+            "{% assign item = 'Hello World' | split: '' | shift: 2 %}{{ item }}{{ item.size }}");
+    }
+}

--- a/src/test/java/liqp/filters/UnshiftTest.java
+++ b/src/test/java/liqp/filters/UnshiftTest.java
@@ -1,0 +1,29 @@
+package liqp.filters;
+
+import static liqp.TestUtils.assertPatternResultEquals;
+
+import org.junit.Test;
+
+import liqp.TemplateParser;
+
+public class UnshiftTest {
+    @Test
+    public void testSimple() {
+        assertPatternResultEquals(TemplateParser.DEFAULT_JEKYLL, "-foo-bar",
+            "{% assign items = \"bar\" | split: \",\" | unshift: \"foo\" %}" +
+                "{% for item in items %}-{{ item }}{% endfor %}");
+    }
+
+    @Test
+    public void testImmutability() {
+        assertPatternResultEquals("unshift should not affect the original array",
+            TemplateParser.DEFAULT_JEKYLL, "-bar",
+            "{% assign items = \"bar\" | split: \",\" %}{% assign itemsCopy = items | unshift: \"foo\" %}" +
+                "{% for item in items %}-{{ item }}{% endfor %}");
+
+        assertPatternResultEquals("unshift should not affect the original list",
+            TemplateParser.DEFAULT_JEKYLL, "-foo-bar",
+            "{% assign items = \"bar\" | split: \",\" | unshift: \"foo\" %}{% assign itemsCopy = items | unshift: \"baz\" %}" +
+                "{% for item in items %}-{{ item }}{% endfor %}");
+    }
+}


### PR DESCRIPTION
Add the remaining 3 array-manipulation filters.

Notably, Jekyll is cool with pop/unshift filtering a non-array, simply returning the unmodified value.