### PR TITLE
Clarify that this project is licensed under the MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2010-2013 by Bart Kiers
 
 Permission is hereby granted, free of charge, to any person
@@ -20,6 +22,3 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
-Project      : Liqp; a Liquid Template grammar/parser
-Developed by : Bart Kiers, bart@big-o.nl

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Liqp; a Liquid Template grammar/parser
+Copyright (c) 2010-2013 by Bart Kiers, bart@big-o.nl


### PR DESCRIPTION
The license text itself was already MIT, but it wasn't explicitly stated so. Renaming to "LICENSE", moving the notice line into a separate "NOTICE" file.

This change also enables GitHub to properly detect the license and show it in the UI.