### PR TITLE
Allow keywords like "offset" in for/assign/capture/tablerow

### DIFF
--- a/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
@@ -141,13 +141,13 @@ for_tag
  ;
 
 for_array
- : TagStart ForStart Id In lookup Reversed? for_attribute* TagEnd
+ : TagStart ForStart id In lookup Reversed? for_attribute* TagEnd
    for_block
    TagStart ForEnd TagEnd
  ;
 
 for_range
- : TagStart ForStart Id In OPar from=expr DotDot to=expr CPar Reversed? for_attribute* TagEnd
+ : TagStart ForStart id In OPar from=expr DotDot to=expr CPar Reversed? for_attribute* TagEnd
    block
    TagStart ForEnd TagEnd
  ;
@@ -168,11 +168,11 @@ attribute
  ;
 
 table_tag
- : TagStart TableStart Id In lookup attribute* TagEnd block TagStart TableEnd TagEnd
+ : TagStart TableStart id In lookup attribute* TagEnd block TagStart TableEnd TagEnd
  ;
 
 capture_tag
- : TagStart CaptureStart Id TagEnd block TagStart CaptureEnd TagEnd  #capture_tag_Id
+ : TagStart CaptureStart id TagEnd block TagStart CaptureEnd TagEnd  #capture_tag_Id
  | TagStart CaptureStart Str TagEnd block TagStart CaptureEnd TagEnd #capture_tag_Str
  ;
 
@@ -210,7 +210,7 @@ param_expr
  ;
 
 assignment
- : TagStart Assign Id EqSign expr filter* TagEnd
+ : TagStart Assign id EqSign expr filter* TagEnd
  ;
 
 expr

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -270,7 +270,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
     List<LNode> expressions = new ArrayList<LNode>();
     expressions.add(new AtomNode(true));
 
-    expressions.add(new AtomNode(ctx.Id().getText()));
+    expressions.add(new AtomNode(ctx.id().getText()));
     expressions.add(visit(ctx.lookup()));
 
     expressions.add(visitBlock(ctx.for_block().a));
@@ -296,7 +296,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
     List<LNode> expressions = new ArrayList<LNode>();
     expressions.add(new AtomNode(false));
 
-    expressions.add(new AtomNode(ctx.Id().getText()));
+    expressions.add(new AtomNode(ctx.id().getText()));
     expressions.add(visit(ctx.from));
     expressions.add(visit(ctx.to));
 
@@ -350,7 +350,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
 
     List<LNode> expressions = new ArrayList<LNode>();
 
-    expressions.add(new AtomNode(ctx.Id().getText()));
+    expressions.add(new AtomNode(ctx.id().getText()));
     expressions.add(visit(ctx.lookup()));
     expressions.add(visitBlock(ctx.block()));
 
@@ -367,7 +367,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
   //  ;
   @Override
   public LNode visitCapture_tag_Id(Capture_tag_IdContext ctx) {
-    return new InsertionNode(insertions.get("capture"), new AtomNode(ctx.Id().getText()), visitBlock(ctx.block()));
+    return new InsertionNode(insertions.get("capture"), new AtomNode(ctx.id().getText()), visitBlock(ctx.block()));
   }
 
   // capture_tag
@@ -507,7 +507,7 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
   @Override
   public LNode visitAssignment(AssignmentContext ctx) {
 
-    AtomNode idNode = new AtomNode(ctx.Id().getText());
+    AtomNode idNode = new AtomNode(ctx.id().getText());
     LNode exprNode = visit(ctx.expr());
     List<LNode> allNodes = new ArrayList<>();
 

--- a/src/test/java/liqp/blocks/CaptureTest.java
+++ b/src/test/java/liqp/blocks/CaptureTest.java
@@ -1,13 +1,15 @@
 package liqp.blocks;
 
-import liqp.Template;
-import liqp.TemplateParser;
-import liqp.exceptions.LiquidException;
+import static liqp.TestUtils.assertPatternResultEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.Template;
+import liqp.TemplateParser;
+import liqp.exceptions.LiquidException;
 
 public class CaptureTest {
 
@@ -132,5 +134,11 @@ public class CaptureTest {
     public void capture_detects_bad_syntaxTest() throws Exception {
 
         TemplateParser.DEFAULT.parse("{{ var2 }}{% capture %}{{ var }} foo {% endcapture %}{{ var2 }}{{ var2 }}");
+    }
+    
+    @Test
+    public void testVariableNamedOffset() throws Exception {
+        assertPatternResultEquals(TemplateParser.DEFAULT, "3",
+            "{% capture offset %}3{% endcapture %}{{offset}}");
     }
 }

--- a/src/test/java/liqp/blocks/ForTest.java
+++ b/src/test/java/liqp/blocks/ForTest.java
@@ -1,24 +1,25 @@
 package liqp.blocks;
 
 import static java.util.Collections.singletonMap;
+import static liqp.TestUtils.assertPatternResultEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Assert;
+import org.junit.Test;
 
 import liqp.RenderSettings;
 import liqp.Template;
 import liqp.TemplateContext;
 import liqp.TemplateParser;
 import liqp.parser.Inspectable;
-import org.antlr.v4.runtime.RecognitionException;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class ForTest {
 
@@ -920,5 +921,14 @@ public class ForTest {
     }
     public void assertTemplateResult(String expected, String template, String data) {
         assertThat(TemplateParser.DEFAULT.parse(template).render(data), is(expected));
+    }
+    
+    @Test
+    public void testVariableNamedOffset() throws Exception {
+        assertPatternResultEquals(TemplateParser.DEFAULT, "123",
+            "{% for offset in (1..3) %}{{ offset }}{% endfor %}");
+
+        assertPatternResultEquals(TemplateParser.DEFAULT, "123",
+            "{% assign offsets = '1,2,3' | split: ',' %}{% for offset in offsets %}{{ offset }}{% endfor %}");
     }
 }

--- a/src/test/java/liqp/blocks/TablerowTest.java
+++ b/src/test/java/liqp/blocks/TablerowTest.java
@@ -1,5 +1,6 @@
 package liqp.blocks;
 
+import static liqp.TestUtils.assertPatternResultEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -456,5 +457,12 @@ public class TablerowTest {
                 .render("{ \"array\" : [{\"id\" : \"id1\"},{\"id\" : \"id2\"}] }"),
                 is("<tr class=\"row1\">\n" +
                         "<td class=\"col1\">id1</td><td class=\"col2\">id2</td></tr>\n"));
+    }
+    
+    @Test
+    public void testVariableNamedOffset() throws Exception {
+        assertPatternResultEquals(TemplateParser.DEFAULT, "<tr class=\"row1\">\n" +
+            "<td class=\"col1\">1</td><td class=\"col2\">2</td><td class=\"col3\">3</td></tr>\n",
+            "{% assign offsets = '1 2 3' | split: ' ' %}{% tablerow offset in offsets %}{{ offset }}{% endtablerow %}");
     }
 }

--- a/src/test/java/liqp/tags/AssignTest.java
+++ b/src/test/java/liqp/tags/AssignTest.java
@@ -1,5 +1,6 @@
 package liqp.tags;
 
+import static liqp.TestUtils.assertPatternResultEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -171,5 +172,10 @@ public class AssignTest {
                 TemplateParser.DEFAULT.parse("{%for i in (1..2) %}{% assign a = \"variable\"%}{% endfor %}{{a}}")
                         .render(),
                 is("variable"));
+    }
+
+    @Test
+    public void testVariableNamedOffset() throws Exception {
+        assertPatternResultEquals(TemplateParser.DEFAULT, "3", "{% assign offset = 3 %}{{offset}}");
     }
 }


### PR DESCRIPTION
Currently we require that the variable names in these blocks/tags are of type "Id", which prevents use to use variable names like "offset". These are commonly used in Jekyll and perfectly fine otherwise.

Change the parser to allow the existing type "id" (lower case) instead of "Id" in these scenarios.