### PR TITLE
Include: jekyll: include variables are mapped to "include" scope

### DIFF
--- a/_includes/include_read_include_var.liquid
+++ b/_includes/include_read_include_var.liquid
@@ -1,0 +1,1 @@
+{{ include.var }}

--- a/src/main/java/liqp/tags/Include.java
+++ b/src/main/java/liqp/tags/Include.java
@@ -42,24 +42,26 @@ public class Include extends Tag {
                 template = context.getParser().parse(includeResourceFile);
             }
 
+            Map<String, Object> variables = new HashMap<String, Object>();
+
             if (nodes.length > 1) {
                 if (context.parseSettings.flavor != Flavor.JEKYLL) {
                     // check if there's a optional "with expression"
                     Object value = nodes[1].render(context);
                     context.put(includeResource, value);
-              } else {
+                } else {
                     // Jekyll-style variable assignments
-                    Map<String, Object> variables = new HashMap<String, Object>();
+                    Map<String, Object> includeMap = new HashMap<>();
+                    variables.put("include", includeMap);
                     for (int i = 1, n = nodes.length; i < n; i++) {
                         @SuppressWarnings("unchecked")
                         Map<String, Object> var = (Map<String, Object>) nodes[i].render(context);
-                        variables.putAll(var);
+                        includeMap.putAll(var);
                     }
-                    return template.renderUnguarded(variables, context, true);
-              }
+                }
             }
-            return template.renderUnguarded(context);
 
+            return template.renderUnguarded(variables, context, true);
         } catch (Exception e) {
             if (context.renderSettings.showExceptionsFromInclude) {
                 throw new RuntimeException("problem with evaluating include", e);

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -87,7 +87,7 @@ public class IncludeTest {
 
     @Test
     public void testIncludeWithExpression() {
-        Template template = Template.parse("{% include include_read_var var=otherVar %}", jekyll());
+        Template template = Template.parse("{% include include_read_include_var var=otherVar %}", jekyll());
         String res = template.render("{ \"otherVar\" : \"TEST\"}");
         assertEquals("TEST", res);
     }
@@ -95,7 +95,7 @@ public class IncludeTest {
     @Test
     public void testIncludeWithMultipleExpressions() {
       Template template = Template.parse(
-          "{% include include_read_var foo=bar var=otherVar var=\"var\" var=yetAnotherVar %}", jekyll());
+          "{% include include_read_include_var foo=bar var=otherVar var=\"var\" var=yetAnotherVar %}", jekyll());
       String res = template.render("{ \"otherVar\" : \"TEST\", \"yetAnotherVar\": \"ANOTHER\"}");
       assertEquals("ANOTHER", res);
     }


### PR DESCRIPTION
In the included file, variables passed as arguments to the include tag are accessible via the "include" scope, not directly (e.g., include.var instead of var)

Fixes incomplete implementation in a48b5f8c.

Fixes https://github.com/bkiers/Liqp/issues/194