### PR TITLE
Add prerender/RenderTransformer

### DIFF
--- a/src/main/java/liqp/RenderTransformer.java
+++ b/src/main/java/liqp/RenderTransformer.java
@@ -4,8 +4,8 @@ import java.io.Writer;
 
 /**
  * <p>
- * A {@link RenderTransformer} handles the conversion of appendable objects in the "prerender"-phase
- * ({@link Template#prerender()} etc.).
+ * A {@link RenderTransformer} handles the conversion of objects to be returned by
+ * {@link Template#renderToObject()} etc.
  * </p>
  * <p>
  * Implementations may optimize how objects are actually appended/serialized, and when exceptions are

--- a/src/main/java/liqp/RenderTransformer.java
+++ b/src/main/java/liqp/RenderTransformer.java
@@ -1,13 +1,40 @@
 package liqp;
 
+import java.io.Writer;
+
 /**
+ * <p>
  * A {@link RenderTransformer} handles the conversion of appendable objects in the "prerender"-phase
  * ({@link Template#prerender()} etc.).
- * 
+ * </p>
+ * <p>
  * Implementations may optimize how objects are actually appended/serialized, and when exceptions are
  * thrown in the case that the final result would be too long.
+ * </p>
+ * The default implementation, {@link RenderTransformerDefaultImpl}, simply appends strings to a
+ * {@link StringBuilder}. While this will work in many cases, there is a chance that large strings are
+ * created temporarily on the heap, increasing the chance of an out-of-memory situation, and a generally
+ * high allocation activity (spikes in the memory allocation graph).
+ * <p>
+ * For example, the following liquid template results in <em>10012</em> {@link StringBuilder}
+ * {@link #toString()} conversions:
+ * 
+ * <pre><code>{% for l in (1..10)%}{% for k in (1..1000) %}
+ *   {% for i in (1..1000) %}Hello! {{ i }} world
+ *{% endfor %}{% endfor %}{% endfor %}</code></pre>
+ * 
+ * With a custom implementation such as stringhold's <a href=
+ * "https://github.com/kohlschutter/stringhold/blob/main/stringhold-liqp/src/main/java/com/kohlschutter/stringhold/liqp/StringHolderRenderTransformer.java">StringHolderReaderTransformer</a>,
+ * the number of actual `toString` conversions can be as low as <em>1</em>, and — depending on specific
+ * implementation tricks (such as reusing instances of identical partial sequences) — a significantly
+ * lower memory footprint can be observed (in this case, with stringhold, <em>7x</em> less usage). If the
+ * data is to be written to a {@link Writer} (instead of serializing to a complete string), an even lower
+ * memory footprint can be achieved (<em>35x</em> less usage was observed).
+ * </p>
  * 
  * @author Christian Kohlschütter
+ * @see RenderTransformerDefaultImpl
+ * @see <a href="https://kohlschutter.github.io/stringhold/">stringhold</a>
  */
 public interface RenderTransformer {
     /**
@@ -40,8 +67,9 @@ public interface RenderTransformer {
     }
 
     /**
-     * Creates a new {@link ObjectAppender.Controller} for the given {@link TemplateContext}, optionally
-     * using the given estimate for the number of calls to {@link ObjectAppender#append(Object)}.
+     * Creates a new {@link RenderTransformer.ObjectAppender.Controller} for the given
+     * {@link TemplateContext}, optionally using the given estimate for the number of calls to
+     * {@link RenderTransformer.ObjectAppender#append(Object)}.
      * 
      * @param context
      *            The template context.

--- a/src/main/java/liqp/RenderTransformer.java
+++ b/src/main/java/liqp/RenderTransformer.java
@@ -1,0 +1,65 @@
+package liqp;
+
+/**
+ * A {@link RenderTransformer} handles the conversion of appendable objects in the "prerender"-phase
+ * ({@link Template#prerender()} etc.).
+ * 
+ * Implementations may optimize how objects are actually appended/serialized, and when exceptions are
+ * thrown in the case that the final result would be too long.
+ * 
+ * @author Christian Kohlschütter
+ */
+public interface RenderTransformer {
+    /**
+     * Something that can append objects.
+     */
+    @FunctionalInterface
+    interface ObjectAppender {
+        /**
+         * Something that can append objects and return the result.
+         */
+        interface Controller extends ObjectAppender {
+            /**
+             * The result of the calls to {@link #append(Object)}.
+             * 
+             * @return The result.
+             */
+            Object getResult();
+
+            @Override
+            void append(Object obj);
+        }
+
+        /**
+         * Appends the given object.
+         * 
+         * @param obj
+         *            The object to append.
+         */
+        void append(Object obj);
+    }
+
+    /**
+     * Creates a new {@link ObjectAppender.Controller} for the given {@link TemplateContext}, optionally
+     * using the given estimate for the number of calls to {@link ObjectAppender#append(Object)}.
+     * 
+     * @param context
+     *            The template context.
+     * @param estimatedNumberOfAppends
+     *            The estimate number of calls to {@link ObjectAppender#append(Object)}.
+     * @return The appender controller instance.
+     */
+    ObjectAppender.Controller newObjectAppender(TemplateContext context, int estimatedNumberOfAppends);
+
+    /**
+     * Transforms an object to a representation that is suitable to call {@link Object#toString()} on
+     * during the "render"-phase ({@link Template#render()} etc.).
+     * 
+     * @param context
+     *            The template context.
+     * @param obj
+     *            The object to transform.
+     * @return The transformed object, or the object itself if no transformation is necessary.
+     */
+    Object transformObject(TemplateContext context, Object obj);
+}

--- a/src/main/java/liqp/RenderTransformerDefaultImpl.java
+++ b/src/main/java/liqp/RenderTransformerDefaultImpl.java
@@ -1,0 +1,58 @@
+package liqp;
+
+import liqp.RenderTransformer.ObjectAppender.Controller;
+
+/**
+ * The default {@link RenderTransformer}.
+ * 
+ * Objects are converted to String, and appended to a {@link StringBuilder} where necessary.
+ */
+final class RenderTransformerDefaultImpl implements RenderTransformer {
+    static final RenderTransformerDefaultImpl INSTANCE = new RenderTransformerDefaultImpl();
+
+    private RenderTransformerDefaultImpl() {
+    }
+
+    @Override
+    public Controller newObjectAppender(TemplateContext context, int estimatedNumberOfAppends) {
+        return new Controller() {
+            private CharSequence result = "";
+            private ObjectAppender appender = (o) -> {
+                result = String.valueOf(o);
+                appender = (o2) -> {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(result);
+                    sb.append(o2);
+
+                    result = sb;
+                    appender = sb::append;
+
+                    checkLength();
+                };
+            };
+
+            private void checkLength() {
+                int maxLen = context.getParser().getProtectionSettings().maxSizeRenderedString;
+                if (result.length() > maxLen) {
+                    throw new RuntimeException("rendered string exceeds " + maxLen);
+                }
+            }
+
+            @Override
+            public Object getResult() {
+                checkLength();
+                return transformObject(context, result);
+            }
+
+            @Override
+            public void append(Object obj) {
+                appender.append(obj);
+            }
+        };
+    }
+
+    @Override
+    public Object transformObject(TemplateContext context, Object obj) {
+        return String.valueOf(obj);
+    }
+}

--- a/src/main/java/liqp/RenderTransformerDefaultImpl.java
+++ b/src/main/java/liqp/RenderTransformerDefaultImpl.java
@@ -5,7 +5,8 @@ import liqp.RenderTransformer.ObjectAppender.Controller;
 /**
  * The default {@link RenderTransformer}.
  * 
- * Objects are converted to String, and appended to a {@link StringBuilder} where necessary.
+ * Objects are converted to {@link CharSequence}, and appended to a {@link StringBuilder} where
+ * necessary. The resulting object is always transformed to {@link String}.
  */
 final class RenderTransformerDefaultImpl implements RenderTransformer {
     static final RenderTransformerDefaultImpl INSTANCE = new RenderTransformerDefaultImpl();
@@ -18,7 +19,7 @@ final class RenderTransformerDefaultImpl implements RenderTransformer {
         return new Controller() {
             private CharSequence result = "";
             private ObjectAppender appender = (o) -> {
-                result = String.valueOf(o);
+                result = o instanceof CharSequence ? (CharSequence) o : String.valueOf(o);
                 appender = (o2) -> {
                     StringBuilder sb = new StringBuilder();
                     sb.append(result);

--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import liqp.RenderTransformer.ObjectAppender;
 import liqp.parser.Flavor;
 
 public class TemplateContext {
@@ -67,7 +68,18 @@ public class TemplateContext {
         this.parent = parent;
     }
 
+    /**
+     * Deprecated. Use {@link TemplateContext#newChildContext(Map)} instead.
+     * 
+     * @param parent The parent context.
+     * @param variables The variables to use in this child context.
+     */
+    @Deprecated
     public TemplateContext(TemplateContext parent, Map<String, Object> variables) {
+        this(variables, parent);
+    }
+
+    protected TemplateContext(Map<String, Object> variables, TemplateContext parent) {
         this(parent);
         this.variables = variables;
     }
@@ -197,5 +209,14 @@ public class TemplateContext {
 
     public ProtectionSettings getProtectionSettings() {
         return parser.getProtectionSettings();
+    }
+
+    public ObjectAppender.Controller newObjectAppender(int estimatedNumberOfAppends) {
+        return renderSettings.getRenderTransformer().newObjectAppender(this,
+                estimatedNumberOfAppends);
+    }
+
+    public TemplateContext newChildContext(Map<String, Object> variablesForChild) {
+        return new TemplateContext(variablesForChild, this);
     }
 }

--- a/src/main/java/liqp/blocks/For.java
+++ b/src/main/java/liqp/blocks/For.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+import liqp.RenderTransformer.ObjectAppender;
 import liqp.TemplateContext;
 import liqp.nodes.AtomNode;
 import liqp.nodes.BlockNode;
@@ -71,9 +72,6 @@ public class For extends Block {
     }
 
     private Object renderArray(String id, TemplateContext context, String tagName, boolean reversed, LNode... tokens) {
-
-        StringBuilder builder = new StringBuilder();
-
         Object data = tokens[2].render(context);
         if (AtomNode.isEmpty(data) || "".equals(data)) {
             data = new ArrayList<>();
@@ -129,6 +127,9 @@ public class For extends Block {
         registry.put(tagName, from + length);
 
         ForLoopDrop forLoopDrop = createLoopDropInStack(context, tagName, length);
+
+        ObjectAppender.Controller builder = context.newObjectAppender(arrayList.size());
+
         try {
             for (Object o : arrayList) {
                 context.incrementIterations();
@@ -143,7 +144,7 @@ public class For extends Block {
             popLoopDropFromStack(context);
         }
 
-        return builder.toString();
+        return builder.getResult();
     }
 
     private ForLoopDrop createLoopDropInStack(TemplateContext context, String tagName, int length) {
@@ -166,7 +167,7 @@ public class For extends Block {
     }
 
 
-    private boolean renderForLoopBody(TemplateContext context, StringBuilder builder, List<LNode> children) {
+    private boolean renderForLoopBody(TemplateContext context, ObjectAppender.Controller builder, List<LNode> children) {
         boolean isBreak = false;
 
         for (LNode node : children) {
@@ -203,9 +204,6 @@ public class For extends Block {
     }
 
     private Object renderRange(String id, TemplateContext context, String tagName, boolean reversed, LNode... tokens) {
-
-        StringBuilder builder = new StringBuilder();
-
         // attributes start from index 7
         Map<String, Integer> attributes = getAttributes(7, context, tagName, tokens);
 
@@ -227,8 +225,9 @@ public class For extends Block {
         int length = (to - from);
 
         ForLoopDrop forLoopDrop = createLoopDropInStack(context, tagName, length);
+        
+        ObjectAppender.Controller builder = context.newObjectAppender(effectiveTo - from + offset + 1);
         try {
-
             for (int i = from + offset; i <= effectiveTo; i++) {
                 int realI;
                 if (reversed) {
@@ -250,8 +249,7 @@ public class For extends Block {
             popLoopDropFromStack(context);
         }
 
-
-        return builder.toString();
+        return builder.getResult();
     }
 
     private Stack<ForLoopDrop> getParentForloopDropStack(TemplateContext context) {

--- a/src/main/java/liqp/blocks/For.java
+++ b/src/main/java/liqp/blocks/For.java
@@ -88,7 +88,7 @@ public class For extends Block {
             data = evaluated.toLiquid();
         }
         if (data instanceof Map) {
-            data = mapAsArray((Map) data);
+            data = mapAsArray((Map<?,?>) data);
         }
         Object[] array = super.asArray(data, context);
 
@@ -194,10 +194,10 @@ public class For extends Block {
                 Object[] arr = super.asArray(value, context);
 
                 for (Object obj : arr) {
-                    builder.append(String.valueOf(obj));
+                    builder.append(obj);
                 }
             } else {
-                builder.append(super.asString(value, context));
+                builder.append(super.asAppendableObject(value, context));
             }
         }
         return isBreak;

--- a/src/main/java/liqp/blocks/Ifchanged.java
+++ b/src/main/java/liqp/blocks/Ifchanged.java
@@ -1,9 +1,10 @@
 package liqp.blocks;
 
+import java.util.Map;
+import java.util.Objects;
+
 import liqp.TemplateContext;
 import liqp.nodes.LNode;
-
-import java.util.*;
 
 public class Ifchanged extends Block {
 
@@ -25,9 +26,10 @@ public class Ifchanged extends Block {
             return null;
         }
 
-        Object rendered = nodes[0].render(context);
+        // Compare strings, so we can match (int)1 == "1"
+        String rendered = String.valueOf(nodes[0].render(context));
         Map<String, Object> registryMap = context.getRegistry(TemplateContext.REGISTRY_IFCHANGED);
-        if (!Objects.equals(rendered, registryMap.get(TemplateContext.REGISTRY_IFCHANGED))) {
+        if (!Objects.equals(rendered, String.valueOf(registryMap.get(TemplateContext.REGISTRY_IFCHANGED)))) {
             registryMap.put(TemplateContext.REGISTRY_IFCHANGED, rendered);
             return rendered;
         } else {

--- a/src/main/java/liqp/blocks/Tablerow.java
+++ b/src/main/java/liqp/blocks/Tablerow.java
@@ -1,6 +1,7 @@
 package liqp.blocks;
 
 import liqp.TemplateContext;
+import liqp.RenderTransformer.ObjectAppender;
 import liqp.nodes.LNode;
 import liqp.parser.LiquidSupport;
 
@@ -71,28 +72,26 @@ public class Tablerow extends Block {
         nestedContext.put(TABLEROWLOOP, tablerowloopDrop);
 
 
-        StringBuilder builder = new StringBuilder();
-
-
-
-        if(total == 0) {
-
+        ObjectAppender.Controller builder = context.newObjectAppender(total * 5);
+        if (total == 0) {
             builder.append("<tr class=\"row1\">\n</tr>\n");
-        }
-        else {
-
-            for(int i = 0, c = 1, r = 0; i < total; i++, c++) {
-
+        } else {
+            for (int i = 0, c = 1, r = 0; i < total; i++, c++) {
                 context.incrementIterations();
 
                 nestedContext.put(valueName, collection[i]);
                 if(c == 1) {
                     r++;
-                    builder.append("<tr class=\"row").append(r).append("\">").append(r == 1 ? "\n" : "");
+                    builder.append("<tr class=\"row");
+                    builder.append(r);
+                    builder.append("\">");
+                    builder.append(r == 1 ? "\n" : "");
                 }
 
-                builder.append("<td class=\"col").append(c).append("\">");
-                builder.append(super.asString(block.render(nestedContext), context));
+                builder.append("<td class=\"col");
+                builder.append(c);
+                builder.append("\">");
+                builder.append(super.asAppendableObject(block.render(nestedContext), context));
                 builder.append("</td>");
 
                 if(c == cols || i == total - 1) {
@@ -106,7 +105,7 @@ public class Tablerow extends Block {
         nestedContext.remove(TABLEROWLOOP);
         nestedContext.remove(valueName);
 
-        return builder.toString();
+        return builder.getResult();
     }
 
     private Map<String, Integer> getAttributes(Object[] collection, int fromIndex, TemplateContext context, LNode... tokens) {

--- a/src/main/java/liqp/filters/Join.java
+++ b/src/main/java/liqp/filters/Join.java
@@ -1,5 +1,6 @@
 package liqp.filters;
 
+import liqp.RenderTransformer.ObjectAppender;
 import liqp.TemplateContext;
 
 public class Join extends Filter {
@@ -16,20 +17,22 @@ public class Join extends Filter {
             return "";
         }
 
-        StringBuilder builder = new StringBuilder();
-
         Object[] array = super.asArray(value, context);
+        if (array.length == 0) {
+            return "";
+        }
+
+        ObjectAppender.Controller builder = context.newObjectAppender(array.length);
         String glue = params.length == 0 ? " " : super.asString(super.get(0, params), context);
 
         for (int i = 0; i < array.length; i++) {
-
-            builder.append(super.asString(array[i], context));
+            builder.append(super.asAppendableObject(array[i], context));
 
             if (i < array.length - 1) {
                 builder.append(glue);
             }
         }
 
-        return builder.toString();
+        return builder.getResult();
     }
 }

--- a/src/main/java/liqp/tags/Include.java
+++ b/src/main/java/liqp/tags/Include.java
@@ -56,7 +56,7 @@ public class Include extends Tag {
                 }
             }
 
-            return template.renderUnguarded(variables, context, true);
+            return template.prerenderUnguarded(variables, context, true);
         } catch (Exception e) {
             if (context.renderSettings.showExceptionsFromInclude) {
                 throw new RuntimeException("problem with evaluating include", e);

--- a/src/main/java/liqp/tags/Include.java
+++ b/src/main/java/liqp/tags/Include.java
@@ -56,7 +56,7 @@ public class Include extends Tag {
                 }
             }
 
-            return template.prerenderUnguarded(variables, context, true);
+            return template.renderToObjectUnguarded(variables, context, true);
         } catch (Exception e) {
             if (context.renderSettings.showExceptionsFromInclude) {
                 throw new RuntimeException("problem with evaluating include", e);

--- a/src/test/java/liqp/RenderSettingsTest.java
+++ b/src/test/java/liqp/RenderSettingsTest.java
@@ -1,11 +1,19 @@
 package liqp;
 
 
-import liqp.exceptions.VariableNotExistException;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import liqp.RenderTransformer.ObjectAppender;
+import liqp.exceptions.VariableNotExistException;
+import liqp.filters.Filter;
 
 public class RenderSettingsTest {
     
@@ -110,5 +118,37 @@ public class RenderSettingsTest {
 
         // Rendering should not terminate
         assertThat(rendered, is("FOO"));
+    }
+
+    @Test
+    public void testEnvironmentMapConfigurator() throws Exception {
+        final String secretKey = getClass() + ".secretKey";
+
+        ParseSettings parseSettings = new ParseSettings.Builder().with(new Filter("secret") {
+            @Override
+            public Object apply(Object value, TemplateContext context, Object... params) {
+                ObjectAppender.Controller sb = context.newObjectAppender(3);
+                sb.append(value);
+                sb.append(" ");
+                sb.append(context.getEnvironmentMap().get(secretKey));
+                return sb.getResult();
+            }
+        }).build();
+
+        AtomicBoolean gotEnvironmentMap = new AtomicBoolean(false);
+        RenderSettings renderSettings = new RenderSettings.Builder().withEnvironmentMapConfigurator((
+            env) -> {
+            env.put(secretKey, "world");
+
+            gotEnvironmentMap.set(true);
+        }).build();
+
+        TemplateParser parser = new TemplateParser.Builder().withParseSettings(parseSettings)
+            .withRenderSettings(renderSettings).build();
+        Template template = parser.parse("{{ 'Hello' | secret }}");
+
+        assertFalse(gotEnvironmentMap.get());
+        assertEquals("Hello world", template.render());
+        assertTrue(gotEnvironmentMap.get());
     }
 }

--- a/src/test/java/liqp/RenderSettingsTest.java
+++ b/src/test/java/liqp/RenderSettingsTest.java
@@ -187,14 +187,14 @@ public class RenderSettingsTest {
         TemplateParser parser = new TemplateParser.Builder().withRenderSettings(renderSettings).build();
         Template template = parser.parse("{{ 'Hello' }} {{ 'world' }}");
 
-        Object obj = template.prerender();
+        Object obj = template.renderToObject();
         assertEquals(MyAppender.class, obj.getClass());
 
         // our custom RenderTransformer allows access to appended fragments
         List<Object> list = ((MyAppender) obj).getList();
         assertEquals(Arrays.asList("Hello", " ", "world"), list);
 
-        // the final output for Template.render and Template.prerender.toString should be identical
+        // the final output for Template.render and Template.renderToObject.toString should be identical
         assertEquals("Hello world", obj.toString());
         assertEquals("Hello world", template.render());
     }


### PR DESCRIPTION
Separate the render-phase into an append-objects phase (prerender) and toString.

This allows the use of more efficient string concatenation implementations, and lazy-evaluation/deferral of the actual string conversion (e.g., via stringhold [1]).

Also add a "withEnvironmentMapConfigurator" option to RenderSettings, which can be useful in this and other scenarios.

[1] https://github.com/kohlschutter/stringhold