### PR TITLE
Shade the ANTLR dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ hs_err_pid*.log
 .pmd
 .pmdruleset.xml
 interpolated-pom.xml
+dependency-reduced-pom.xml
 
 target/
 build/

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,28 @@
           </excludes>
         </configuration>
       </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.antlr</pattern>
+                  <shadedPattern>liqp.org.antlr</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <antlr.version>3.5.1</antlr.version>
-    <antlr4.version>4.10.1</antlr4.version>
+    <antlr4.version>4.7.2</antlr4.version>
     <jackson.databind.version>2.13.4.1</jackson.databind.version>
     <jackson.version>2.13.2</jackson.version>
     <jsoup.version>1.15.3</jsoup.version>


### PR DESCRIPTION
This is a first crack at using Maven Shade to relocate the antlr packages so that there shouldn't be conflicts with other versions of ANTLR. From my testing, this appears to work to solve the problems encountered in #256 and should allow the release to still be built for Java 8.

As @kohlschuetter mentioned in #256, there's methods like [Template#getParseTree](https://github.com/bkiers/Liqp/blob/0c382a7694ba7df8b37b652c846f3339607b0e09/src/main/java/liqp/Template.java#LL246C26-L246C26) that would change in terms of what class is being used. Existing users would need to modify their packages to import `import liqp.org.antlr.v4.runtime.tree.ParseTree;`. This is obviously a breaking change, so it might be worthwhile of a 0.9 version bump, but it would at least continue to offer the ability to access the tree, though it wouldn't be API compatible with something that expects to interact with a `org.antlr.v4.runtime.tree.ParseTree;`.

It might be worth marking this method as deprecated if the idea is to make this an API that would be removed in a 1.0 release or something.

Let me know your thoughts @msangel @kohlschuetter!