### PR TITLE
Surface nestedContext errors when withRaiseExceptionsInStrictMode is False

### DIFF
--- a/src/main/java/liqp/blocks/For.java
+++ b/src/main/java/liqp/blocks/For.java
@@ -67,6 +67,12 @@ public class For extends Block {
 
         Object rendered = array ? renderArray(id, nestedContext, tagName, reversed, nodes) : renderRange(id, nestedContext, tagName, reversed, nodes);
 
+        // When context.renderSettings.raiseExceptionsInStrictMode=false,
+        // don't allow nested errors to be lost
+        for (RuntimeException nestedError : nestedContext.errors()) {
+            context.addError(nestedError);
+        }
+
         return rendered;
     }
 

--- a/src/test/java/liqp/RenderSettingsTest.java
+++ b/src/test/java/liqp/RenderSettingsTest.java
@@ -13,6 +13,14 @@ public class RenderSettingsTest {
         return new TemplateParser.Builder().withRenderSettings(new RenderSettings.Builder()
                 .withStrictVariables(true).build()).build();
     }
+
+    protected TemplateParser parserWithStrictVariablesAndRaiseExceptionsInStrictModeFalse() {
+        RenderSettings renderSettings = new RenderSettings.Builder()
+                .withStrictVariables(true)
+                .withRaiseExceptionsInStrictMode(false)
+                .build();
+        return new TemplateParser.Builder().withRenderSettings(renderSettings).build();
+    }
     
     @Test
     public void renderWithStrictVariables1() {
@@ -92,12 +100,7 @@ public class RenderSettingsTest {
 
     @Test
     public void raiseExceptionsInStrictModeFalseTest() {
-        RenderSettings renderSettings = new RenderSettings.Builder()
-                .withStrictVariables(true)
-                .withRaiseExceptionsInStrictMode(false)
-                .build();
-        
-        TemplateParser parser = new TemplateParser.Builder().withRenderSettings(renderSettings).build();
+        TemplateParser parser = parserWithStrictVariablesAndRaiseExceptionsInStrictModeFalse();
 
         Template template = parser.parse("{{a}}{{b}}{{c}}");
 
@@ -107,6 +110,27 @@ public class RenderSettingsTest {
 
         // There should be 2 exceptions recorded for non-existing variables `a` and `c`
         assertThat(template.errors().size(), is(2));
+
+        // Rendering should not terminate
+        assertThat(rendered, is("FOO"));
+    }
+
+    @Test
+    public void raiseExceptionsInStrictModeFalseTest2() {
+        TemplateParser parser = parserWithStrictVariablesAndRaiseExceptionsInStrictModeFalse();
+
+        Template template = parser.parse("{% for v in a %}{{v.b}}{% endfor %}" +
+                                         "{% for v in badVariableName %}{{v.b}}{% endfor %}" +
+                                         "{% for v in a %}{{v.badVariableName}}{% endfor %}");
+
+        assertThat(template.errors().size(), is(0));
+
+        String rendered = template.render("{\"a\" : [ { \"b\" : \"FOO\" } ] }");
+
+        // There should be 2 exceptions recorded for non-existing variables `badVariableName` and `v.badVariableName`
+        assertThat(template.errors().size(), is(2));
+        assertThat(((VariableNotExistException) template.errors().get(0)).getVariableName(), is("badVariableName"));
+        assertThat(((VariableNotExistException) template.errors().get(1)).getVariableName(), is("v.badVariableName"));
 
         // Rendering should not terminate
         assertThat(rendered, is("FOO"));


### PR DESCRIPTION
Currently we allow each tag to maintain its own context that keeps track of its own variables (for scope). When using `RenderSettings.withRaiseExceptionsInStrictMode(false)`, any errors added to a nestedContext during a `For#render()` are lost and not bubbled up to the `Template` after rendering is complete.

Changes the `For` `render()` method to include child errors in the parent's `context`.

Would appreciate it if you could take a look @bkiers or @msangel