### PR TITLE
Fix renderToObject method visibility

### DIFF
--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -552,7 +552,7 @@ public class Template {
     }
 
     @SuppressWarnings("unchecked")
-    private Object renderToObject(String jsonMap) {
+    public Object renderToObject(String jsonMap) {
         Map<String, Object> map;
 
         try {


### PR DESCRIPTION
Make renderToObject(String) public
    
This convenient method was accidentally left private.
