### PR TITLE
LookupNode: Add support for non-List Collections

### DIFF
--- a/src/main/java/liqp/nodes/LookupNode.java
+++ b/src/main/java/liqp/nodes/LookupNode.java
@@ -207,7 +207,6 @@ public class LookupNode implements LNode {
                     return null;
                 }
                 else {
-                    // FIXME handle this
                     return null;
                 }
             }

--- a/src/main/java/liqp/nodes/LookupNode.java
+++ b/src/main/java/liqp/nodes/LookupNode.java
@@ -1,14 +1,15 @@
 package liqp.nodes;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import liqp.TemplateContext;
 import liqp.exceptions.VariableNotExistException;
 import liqp.parser.Inspectable;
 import liqp.parser.LiquidSupport;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 public class LookupNode implements LNode {
 
@@ -176,16 +177,37 @@ public class LookupNode implements LNode {
 
             key = expression.render(context);
 
-            if(key instanceof Number) {
+            if (key instanceof Number) {
                 int index = ((Number)key).intValue();
 
-                if(value.getClass().isArray()) {
-                    return ((Object[])value)[index];
+                if (value.getClass().isArray()) {
+                    Object[] arr = ((Object[]) value);
+                    if (index >= arr.length) {
+                        return null;
+                    } else {
+                        return arr[index];
+                    }
                 }
-                else if(value instanceof List) {
-                    return ((List<?>)value).get(index);
+                else if (value instanceof List) {
+                    List<?> list = ((List<?>) value);
+                    if (index >= list.size()) {
+                        return null;
+                    }
+                    return list.get(index);
+                } else if (value instanceof Collection) {
+                    Collection<?> coll = (Collection<?>) value;
+                    int i = 0;
+                    for (Iterator<?> it = coll.iterator(); it.hasNext();) {
+                        Object obj = it.next();
+                        if (i == index) {
+                            return obj;
+                        }
+                        i++;
+                    }
+                    return null;
                 }
                 else {
+                    // FIXME handle this
                     return null;
                 }
             }

--- a/src/main/java/liqp/nodes/LookupNode.java
+++ b/src/main/java/liqp/nodes/LookupNode.java
@@ -184,18 +184,37 @@ public class LookupNode implements LNode {
                     Object[] arr = ((Object[]) value);
                     if (index >= arr.length) {
                         return null;
-                    } else {
-                        return arr[index];
+                    } else if (index < 0) {
+                        index = arr.length + index;
+                        if (index < 0) {
+                            return null;
+                        }
                     }
+                    return arr[index];
                 }
                 else if (value instanceof List) {
                     List<?> list = ((List<?>) value);
-                    if (index >= list.size()) {
+                    int size = list.size();
+                    if (index >= size) {
                         return null;
+                    } else if (index < 0) {
+                        index = size + index;
+                        if (index < 0) {
+                            return null;
+                        }
                     }
                     return list.get(index);
                 } else if (value instanceof Collection) {
                     Collection<?> coll = (Collection<?>) value;
+
+                    if (index < 0) {
+                       index = coll.size() + index;
+                       if (index < 0) {
+                           return null;
+                       }
+                       return new ArrayList<>(coll).get(index);
+                    }
+
                     int i = 0;
                     for (Iterator<?> it = coll.iterator(); it.hasNext();) {
                         Object obj = it.next();

--- a/src/test/java/liqp/nodes/LookupNodeTest.java
+++ b/src/test/java/liqp/nodes/LookupNodeTest.java
@@ -319,5 +319,15 @@ public class LookupNodeTest {
         assertEquals("Hello world", TemplateParser.DEFAULT.parse("Hello {{data[1]}}").render(Collections
             .singletonMap("data", new LinkedHashSet<>(Arrays.asList("hello", "world")))));
     }
+
+    @Test
+    public void testNegativeOffset() throws Exception {
+        assertEquals("Hello hello", TemplateParser.DEFAULT.parse("Hello {{data[-2]}}").render(Collections
+            .singletonMap("data", new LinkedHashSet<>(Arrays.asList("hello", "world")))));
+        assertEquals("Hello hello", TemplateParser.DEFAULT.parse("Hello {{data[-2]}}").render(Collections
+            .singletonMap("data", Arrays.asList("hello", "world"))));
+        assertEquals("Hello hello", TemplateParser.DEFAULT.parse("Hello {{data[-2]}}").render(Collections
+            .singletonMap("data", new String[]{"hello", "world"})));
+    }
 }
 

--- a/src/test/java/liqp/nodes/LookupNodeTest.java
+++ b/src/test/java/liqp/nodes/LookupNodeTest.java
@@ -2,9 +2,13 @@ package liqp.nodes;
 
 import static liqp.TestUtils.getNode;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import org.antlr.v4.runtime.RecognitionException;
@@ -308,6 +312,12 @@ public class LookupNodeTest {
         String assigns = "{ \"Data\" : { \"1\" : { \"Value\": \"tobi\" } } }";
 
         assertThat(TemplateParser.DEFAULT.parse("hi {{Data.1.Value}}").render(assigns), is("hi tobi"));
+    }
+
+    @Test
+    public void collectionTest() throws Exception {
+        assertEquals("Hello world", TemplateParser.DEFAULT.parse("Hello {{data[1]}}").render(Collections
+            .singletonMap("data", new LinkedHashSet<>(Arrays.asList("hello", "world")))));
     }
 }
 


### PR DESCRIPTION
We currently don't support accessing a Collection by index, unless it is a List.

Add an Iterator-based approach to accessing non-List Collections (e.g., LinkedHashSet) by index.