### PR TITLE
exclude-non-antlr-from-shaded-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
           </excludes>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -230,6 +230,21 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
+              <artifactSet>
+                <includes>
+                  <include>org.antlr</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>org.antlr</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>org.antlr</pattern>


### PR DESCRIPTION
The shaded JAR being built currently includes all of the dependencies. This excludes them all except for ANTLR. This fixes #272