### PR TITLE
Update antlr4 dependency version from 4.7.2 to 4.13.0; update CI scripts to always build with Java 11 but still targeting and testing Java 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,16 @@ jobs:
            java-version: 8
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: ${{ matrix.java-version }}
+          architecture: x64
+          java-version: |
+            ${{ matrix.java-version }}
+            11
           cache: 'maven'
       - name: Build & Test
-        run: ./mvnw -B verify
+        run: ./mvnw -B verify && if [[ "${{ matrix.java-version }}" != "11" ]]; then JAVA_HOME="$JAVA_HOME_${{ matrix.java-version }}_X64" ./mvnw -B verify -P \!antlr,antlr-skip; fi
       - name: Generate JaCoCo Badge
         if: ${{ matrix.jacoco }}
         uses: cicirello/jacoco-badge-generator@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             11
           cache: 'maven'
       - name: Build & Test
-        run: ./mvnw -B verify && if [[ "${{ matrix.java-version }}" != "11" ]]; then JAVA_HOME="$JAVA_HOME_${{ matrix.java-version }}_X64" ./mvnw -B verify -P \!antlr,antlr-skip; fi
+        run: ./mvnw -B verify && if [[ "${{ matrix.java-version }}" != "11" ]]; then JAVA_HOME="$JAVA_HOME_${{ matrix.java-version }}_X64" ./mvnw -B verify -P antlr-skip; fi
       - name: Generate JaCoCo Badge
         if: ${{ matrix.jacoco }}
         uses: cicirello/jacoco-badge-generator@v2

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <antlr.version>3.5.1</antlr.version>
-    <antlr4.version>4.7.2</antlr4.version>
+    <antlr4.version>4.13.0</antlr4.version>
     <jackson.databind.version>2.13.4.2</jackson.databind.version>
     <jackson.version>2.13.2</jackson.version>
     <jsoup.version>1.15.3</jsoup.version>

--- a/pom.xml
+++ b/pom.xml
@@ -140,25 +140,6 @@
     </pluginManagement>
 
     <plugins>
-
-      <plugin>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-maven-plugin</artifactId>
-        <version>${antlr4.version}</version>
-        <configuration>
-          <arguments>
-            <argument>-visitor</argument>
-          </arguments>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>antlr4</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -286,6 +267,59 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>antlr</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-maven-plugin</artifactId>
+            <version>${antlr4.version}</version>
+            <configuration>
+              <arguments>
+                <argument>-visitor</argument>
+              </arguments>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>antlr4</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>antlr-skip</id>
+      <build>
+        <plugins>
+          <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/antlr4</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>ossrh-release</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,25 @@
 
     <plugins>
       <plugin>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-maven-plugin</artifactId>
+        <version>${antlr4.version}</version>
+        <configuration>
+          <arguments>
+            <argument>-visitor</argument>
+          </arguments>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>antlr4</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
@@ -150,7 +169,6 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -268,55 +286,39 @@
 
   <profiles>
     <profile>
-      <id>antlr</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
+      <id>antlr-skip</id>
       <build>
         <plugins>
           <plugin>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-maven-plugin</artifactId>
             <version>${antlr4.version}</version>
-            <configuration>
-              <arguments>
-                <argument>-visitor</argument>
-              </arguments>
-            </configuration>
             <executions>
               <execution>
-                <goals>
-                  <goal>antlr4</goal>
-                </goals>
+                <id>default</id>
+                <phase>none</phase>
               </execution>
             </executions>
           </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>antlr-skip</id>
-      <build>
-        <plugins>
           <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>target/generated-sources/antlr4</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.4.0</version>
+            <executions>
+              <execution>
+                <id>add-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>target/generated-sources/antlr4</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
This fixes a "unused import" warning in target/generated-sources.