### PR TITLE
LiquidParser: Fix antlr warning about matching an empty string

### DIFF
--- a/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
@@ -217,13 +217,13 @@ jekyll_include_params
  ;
 
 output
- : {evaluateInOutputTag}? outStart evaluate=expr filter* OutEnd
+ : {isEvaluateInOutputTag()}? outStart evaluate=expr filter* OutEnd
  | {isStrict()}? outStart term filter* OutEnd
  | {isWarn() || isLax()}? outStart term filter* unparsed=not_out_end? OutEnd
  ;
 
 not_out_end
- : ~( OutEnd )*
+ : ( ~OutEnd )+
  ;
 
 filter

--- a/src/test/java/liqp/parser/v4/LiquidParserTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidParserTest.java
@@ -387,12 +387,12 @@ public class LiquidParserTest {
 
         assertThat(
                 texts("{{ true }}", "output"),
-                equalTo(array("{{", "true", "", "}}"))
+                equalTo(array("{{", "true", "}}"))
         );
 
         assertThat(
                 texts("{{ 'some string here' | uppercase }}", "output"),
-                equalTo(array("{{", "'some string here'", "|uppercase", "", "}}"))
+                equalTo(array("{{", "'some string here'", "|uppercase", "}}"))
         );
     }
 


### PR DESCRIPTION
antlr rightfully complains: "rule output contains an optional block with at least one alternative that can match an empty string" (which hints at a potential performance problem).

This is due to "not_out_end" matching with "*" (which can yield an empty string), even though we already specify "?" at "unparsed=not_out_end?".

Fix the parser grammar, and adjust two test cases where we actually tested for that undesired behavior.

Also see
https://stackoverflow.com/questions/26041293/antlr-4-warning-rule-contains-an-optional-block-with-at-least-one-alternative for an explanation.