### PR TITLE
ruby: run_with*.sh should use realpath for shared folder

### DIFF
--- a/ruby/run_with_jekyll.sh
+++ b/ruby/run_with_jekyll.sh
@@ -5,7 +5,7 @@ if ! docker inspect ruby_with_jekyll > /dev/null 2>&1; then
 fi
 
 docker run -it --rm --name jekyll \
-    --volume=$PWD:/srv/jekyll \
+    --volume="$(realpath 2>/dev/null || pwd)":/srv/jekyll \
     -p 1234:1234 \
      ruby_with_jekyll \
      $1

--- a/ruby/run_with_liquid.sh
+++ b/ruby/run_with_liquid.sh
@@ -5,6 +5,6 @@ if ! docker inspect ruby_with_liquid > /dev/null 2>&1; then
 fi
 
 docker run -it --rm --name liquid \
-    --volume=$PWD:/srv/liquid \
+     --volume="$(realpath 2>/dev/null || pwd)":/srv/liquid \
      ruby_with_liquid \
      $1


### PR DESCRIPTION
On macOS, the Docker app uses the canonical path (symlinks resolved) for shared folders.

This prevents sharing the directory containing the ruby scripts if the path of the current working directory contains any directory symlinks.

Use realpath instead of pwd in these scripts, falling back to using pwd when realpath is not available.