### PR TITLE
ruby: Fix Dockerfiles for Jekyll/Liquid images

### DIFF
--- a/ruby/docker_images/jekyll/Dockerfile
+++ b/ruby/docker_images/jekyll/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM ruby:3.3-alpine
 
 RUN mkdir -p /usr/local/etc \
   && { \
@@ -7,18 +7,10 @@ RUN mkdir -p /usr/local/etc \
   } >> /etc/gemrc
 
 RUN apk update && apk add --no-cache \
-  ruby \
-  ruby-irb \
-  ruby-json \
-  ruby-bundler \
-  ruby-bigdecimal \
-	ruby-dev \
-	build-base \
-  libssl1.1 \
+  build-base \
   libc6-compat
 
 RUN gem install jekyll
-RUN gem install ruby-debug-ide
 
 RUN mkdir -p /srv/jekyll
 WORKDIR /srv/jekyll

--- a/ruby/docker_images/liquid/Dockerfile
+++ b/ruby/docker_images/liquid/Dockerfile
@@ -12,10 +12,10 @@ RUN apk update && apk add --no-cache \
   ruby-json \
   ruby-bundler \
   ruby-bigdecimal \
-	ruby-dev \
-	build-base \
-  libssl1.1 \
-  libc6-compat
+  ruby-dev \
+  build-base \
+  libc6-compat \
+  linux-headers
 
 RUN gem install liquid
 RUN gem install ruby-debug-ide


### PR DESCRIPTION
Both images would not build for recent Alpine.

The Jekyll Docker image would fail upon running ruby with a segmentation fault, at least on aarch64 macOS.

Update the Alpine apk dependencies, and change the Jekyll base image to a ruby-provided Alpine build.