### PR TITLE
Fix number comparisons when applying filters, BigDecimal handling

### DIFF
--- a/src/main/java/liqp/LValue.java
+++ b/src/main/java/liqp/LValue.java
@@ -279,16 +279,16 @@ public abstract class LValue {
         if (number == null) {
             return null;
         }
-        if (number instanceof BigDecimal) {
-            return (BigDecimal) number;
+        if (number instanceof PlainBigDecimal) {
+            return (PlainBigDecimal) number;
         }
-        return new BigDecimal(number.toString().trim());
+        return new PlainBigDecimal(number.toString().trim());
     }
 
     // mimic ruby's `BigDecimal.to_f` with standard java capabilities
     // same time provide expected out for java.math.BigDecimal
-    public static String asFormattedNumber(BigDecimal bd) {
-        return bd.setScale(Math.max(1, bd.stripTrailingZeros().scale()), RoundingMode.UNNECESSARY).toPlainString();
+    public static BigDecimal asFormattedNumber(BigDecimal bd) {
+        return bd.setScale(Math.max(1, bd.stripTrailingZeros().scale()), RoundingMode.UNNECESSARY);
     }
     
     /**

--- a/src/main/java/liqp/PlainBigDecimal.java
+++ b/src/main/java/liqp/PlainBigDecimal.java
@@ -1,0 +1,22 @@
+package liqp;
+
+import java.math.BigDecimal;
+
+/**
+ * A {@link BigDecimal} with a {@link #toString()} method that is equivalent to calling
+ * {@link #toPlainString()}.
+ * 
+ * @author Christian Kohlschütter
+ */
+public final class PlainBigDecimal extends BigDecimal {
+    private static final long serialVersionUID = 1L;
+
+    public PlainBigDecimal(String val) {
+        super(val);
+    }
+
+    @Override
+    public String toString() {
+        return toPlainString();
+    }
+}

--- a/src/main/java/liqp/filters/Abs.java
+++ b/src/main/java/liqp/filters/Abs.java
@@ -1,6 +1,6 @@
 package liqp.filters;
 
-import java.math.BigDecimal;
+import liqp.PlainBigDecimal;
 
 public class Abs extends Filter {
 
@@ -29,7 +29,7 @@ public class Abs extends Filter {
         }
 
         if (super.isNumber(value) || super.canBeDouble(value)) {
-            return asFormattedNumber(new BigDecimal(super.asNumber(value).toString()).abs());
+            return asFormattedNumber(new PlainBigDecimal(super.asNumber(value).toString()).abs());
         }
 
         return 0;

--- a/src/main/java/liqp/filters/Minus.java
+++ b/src/main/java/liqp/filters/Minus.java
@@ -2,6 +2,8 @@ package liqp.filters;
 
 import java.math.BigDecimal;
 
+import liqp.PlainBigDecimal;
+
 public class Minus extends Filter {
 
     /*
@@ -24,8 +26,8 @@ public class Minus extends Filter {
             return super.asNumber(value).longValue() - super.asNumber(rhsObj).longValue();
         }
 
-        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
-        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        BigDecimal first = new PlainBigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new PlainBigDecimal(super.asNumber(rhsObj).toString());
         return asFormattedNumber(first.subtract(second));
     }
 }

--- a/src/main/java/liqp/filters/Modulo.java
+++ b/src/main/java/liqp/filters/Modulo.java
@@ -2,6 +2,7 @@ package liqp.filters;
 
 import java.math.BigDecimal;
 
+import liqp.PlainBigDecimal;
 import liqp.TemplateContext;
 
 public class Modulo extends Filter {
@@ -26,8 +27,8 @@ public class Modulo extends Filter {
             return super.asNumber(value).longValue() % super.asNumber(rhsObj).longValue();
         }
 
-        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
-        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        BigDecimal first = new PlainBigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new PlainBigDecimal(super.asNumber(rhsObj).toString());
         return asFormattedNumber(first.remainder(second));
     }
 }

--- a/src/main/java/liqp/filters/Plus.java
+++ b/src/main/java/liqp/filters/Plus.java
@@ -2,6 +2,8 @@ package liqp.filters;
 
 import java.math.BigDecimal;
 
+import liqp.PlainBigDecimal;
+
 public class Plus extends Filter {
 
     /*
@@ -23,8 +25,8 @@ public class Plus extends Filter {
         if (super.canBeInteger(value) && super.canBeInteger(rhsObj)) {
             return super.asNumber(value).longValue() + super.asNumber(rhsObj).longValue();
         }
-        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
-        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        BigDecimal first = new PlainBigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new PlainBigDecimal(super.asNumber(rhsObj).toString());
         return asFormattedNumber(first.add(second));
     }
 }

--- a/src/main/java/liqp/filters/Round.java
+++ b/src/main/java/liqp/filters/Round.java
@@ -1,8 +1,9 @@
 package liqp.filters;
 
-import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+
+import liqp.PlainBigDecimal;
 
 public class Round extends Filter {
 
@@ -32,6 +33,6 @@ public class Round extends Filter {
         DecimalFormat formatter = new DecimalFormat(formatBuilder.toString());
         formatter.setRoundingMode(RoundingMode.HALF_UP);
 
-        return new BigDecimal(formatter.format(number));
+        return new PlainBigDecimal(formatter.format(number));
     }
 }

--- a/src/main/java/liqp/filters/Times.java
+++ b/src/main/java/liqp/filters/Times.java
@@ -2,6 +2,8 @@ package liqp.filters;
 
 import java.math.BigDecimal;
 
+import liqp.PlainBigDecimal;
+
 public class Times extends Filter {
 
     /*
@@ -24,8 +26,8 @@ public class Times extends Filter {
             return super.asNumber(value).longValue() * super.asNumber(rhsObj).longValue();
         }
 
-        BigDecimal first = new BigDecimal(super.asNumber(value).toString());
-        BigDecimal second = new BigDecimal(super.asNumber(rhsObj).toString());
+        BigDecimal first = new PlainBigDecimal(super.asNumber(value).toString());
+        BigDecimal second = new PlainBigDecimal(super.asNumber(rhsObj).toString());
         return first.multiply(second);
     }
 }

--- a/src/main/java/liqp/nodes/ContainsNode.java
+++ b/src/main/java/liqp/nodes/ContainsNode.java
@@ -1,11 +1,11 @@
 package liqp.nodes;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import liqp.LValue;
+import liqp.PlainBigDecimal;
 import liqp.TemplateContext;
 import liqp.parser.Inspectable;
 import liqp.parser.LiquidSupport;
@@ -51,7 +51,7 @@ public class ContainsNode extends LValue implements LNode {
 
     private Object toSingleNumberType(Object needle) {
         if (needle instanceof Number) {
-            needle = LValue.asFormattedNumber(new BigDecimal(needle.toString()));
+            needle = LValue.asFormattedNumber(new PlainBigDecimal(needle.toString()));
         }
         return needle;
     }
@@ -60,7 +60,7 @@ public class ContainsNode extends LValue implements LNode {
         ArrayList<Object> res = new ArrayList<>(asList.size());
         for(Object item: asList) {
             if (item instanceof Number) {
-                res.add(LValue.asFormattedNumber(new BigDecimal(item.toString())));
+                res.add(LValue.asFormattedNumber(new PlainBigDecimal(item.toString())));
             } else {
                 res.add(item);
             }

--- a/src/main/java/liqp/nodes/OutputNode.java
+++ b/src/main/java/liqp/nodes/OutputNode.java
@@ -1,5 +1,6 @@
 package liqp.nodes;
 
+import liqp.PlainBigDecimal;
 import liqp.TemplateContext;
 import liqp.TemplateParser;
 import liqp.exceptions.LiquidException;
@@ -51,12 +52,12 @@ public class OutputNode implements LNode {
                  }
                 context.addError(new LiquidException("unexpected output: " + localUnparsed, unparsedline, unparsedPosition, null));
             }
-
         }
 
-        if (value instanceof BigDecimal) {
-            value = ((BigDecimal) value).toPlainString();
+        if (value instanceof BigDecimal && !(value instanceof PlainBigDecimal)) {
+            value = new PlainBigDecimal(value.toString());
         }
+
         return value;
     }
 }

--- a/src/test/java/liqp/filters/TimesTest.java
+++ b/src/test/java/liqp/filters/TimesTest.java
@@ -5,14 +5,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import liqp.LValue;
+import java.math.BigDecimal;
+
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
+import liqp.LValue;
+import liqp.PlainBigDecimal;
 import liqp.Template;
 import liqp.TemplateParser;
-
-import java.math.BigDecimal;
 
 public class TimesTest {
 
@@ -71,8 +72,11 @@ public class TimesTest {
         assertThat(filter.apply(3L, 4L), is((Object)12L));
         // assert_template_result "0", "{{ 'foo' | times:4 }}" // see: applyTest()
         assertTrue(String.valueOf(filter.apply(2.1, 3L)).matches("6[.,]3"));
-        assertEquals("7.25", LValue.asFormattedNumber((BigDecimal) filter.apply(0.0725, 100)));
-        assertEquals("-7.25", LValue.asFormattedNumber((BigDecimal) filter.apply(-0.0725, 100)));
-        assertEquals("7.25", LValue.asFormattedNumber((BigDecimal) filter.apply(-0.0725, -100)));
+        assertEquals(new PlainBigDecimal("7.25"), LValue.asFormattedNumber((BigDecimal) filter.apply(
+            0.0725, 100)));
+        assertEquals(new PlainBigDecimal("-7.25"), LValue.asFormattedNumber((BigDecimal) filter.apply(
+            -0.0725, 100)));
+        assertEquals(new PlainBigDecimal("7.25"), LValue.asFormattedNumber((BigDecimal) filter.apply(
+            -0.0725, -100)));
     }
 }

--- a/src/test/java/liqp/nodes/GtNodeTest.java
+++ b/src/test/java/liqp/nodes/GtNodeTest.java
@@ -15,14 +15,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import liqp.exceptions.LiquidException;
-import liqp.parser.Flavor;
 import org.antlr.v4.runtime.RecognitionException;
 import org.junit.Test;
 
 import liqp.Template;
 import liqp.TemplateParser;
 import liqp.TemplateTest;
+import liqp.exceptions.LiquidException;
+import liqp.parser.Flavor;
 import liqp.parser.Inspectable;
 
 public class GtNodeTest {
@@ -125,5 +125,13 @@ public class GtNodeTest {
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("not the same type"));
         }
+    }
+
+    @Test
+    public void testFilterCompare() {
+        String result = new TemplateParser.Builder().withFlavor(Flavor.JEKYLL).build() //
+            .parse("{% assign score = 0 | plus: 1.0 %}{% if score > 0 %}true{% else %}false{% endif %}")
+            .render();
+        assertTrue(Boolean.parseBoolean(result));
     }
 }


### PR DESCRIPTION
When comparing numbers in Jekyll flavor, comparisons would fail if a filter like "plus" was applied (e.g., "Cannot compare 1.0 with 0 because they are not the same type: java.lang.String vs java.math.BigDecimal").

This is due to premature BigDecimal-to-String conversion.

Introduce a BigDecimal subclass, PlainBigDecimal, whose toString() method calls toPlainString(), and defer toString() conversion as far as possible.