### PR TITLE
Differentiate between null and missing values

### DIFF
--- a/src/main/java/liqp/TemplateContext.java
+++ b/src/main/java/liqp/TemplateContext.java
@@ -7,11 +7,13 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import liqp.RenderTransformer.ObjectAppender;
 import liqp.exceptions.ExceededMaxIterationsException;
 
 public class TemplateContext {
+    private static final AtomicBoolean FOUND_DUMMY = new AtomicBoolean(false);
 
     public static final String REGISTRY_CYCLE = "cycle";
     public static final String REGISTRY_IFCHANGED = "ifchanged";
@@ -99,20 +101,23 @@ public class TemplateContext {
     }
 
     public Object get(String key) {
+        return get(key, FOUND_DUMMY);
+    }
 
+    public Object get(String key, AtomicBoolean found) {
         // First try to retrieve the key from the local context
-        Object value = this.variables.get(key);
-
-        if (value != null) {
-            return value;
+        if (this.variables.containsKey(key)) {
+            found.set(true);
+            return this.variables.get(key);
         }
 
         if (parent != null) {
             // Not available locally, try the parent context
-            return parent.get(key);
+            return parent.get(key, found);
         }
 
         // Not available
+        found.set(false);
         return null;
     }
 


### PR DESCRIPTION
Currently, we would get a VariableNotExistException when in strict mode, even if a page property, for example, is knowingly set to null.

This is specifically important since {% if val %} returns true even for empty strings, making it almost impossible to avoid an exception and still support properties like page.last_modified_at.

Introduce a "found" state when traversing structures, and only consider a non-existant variable if found=false

This change breaks backwards compatibility with classes implementing LookupNode.Indexable. This is considered low-risk at the moment.