### PR TITLE
Permit variables in Liquid-style tag 'include with'

### DIFF
--- a/ruby/cases_include_with_syntax_with.rb
+++ b/ruby/cases_include_with_syntax_with.rb
@@ -32,6 +32,8 @@ if isJekyll
 else
   Liquid::Template.file_system = Liquid::LocalFileSystem.new("cases_variable_inside_import/_includes", "%s.liquid")
   assertEqual("color: 'red'", render({"var" => "there"}, "{% include 'color' with 'red' %}"))
+  assertEqual("color: 'blue'", render({"clr" => "blue"}, "{% include 'color' with clr %}"))
+  assertEqual("color: 'yellow'", render({}, "{% assign clr = 'yellow' %}{% include 'color' with clr %}"))
   # liquid variable evaluate
   assertEqual("there", render({"var" => "there", "tmpl" => "include_read_var"}, "{% include tmpl %}"))
 end

--- a/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
@@ -202,7 +202,7 @@ capture_tag
  ;
 
 include_tag
- : {isLiquidStyleInclude()}? TagStart liquid=Include expr (With Str)? TagEnd
+ : {isLiquidStyleInclude()}? TagStart liquid=Include expr (With expr)? TagEnd
  | {isJekyllStyleInclude()}? TagStart jekyll=Include file_name_or_output (jekyll_include_params)* TagEnd
  ;
 

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -458,10 +458,10 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
     if (ctx.jekyll != null) {
       return getJekyllIncludeInsertionNode("include", ctx.file_name_or_output(), ctx.jekyll_include_params());
     } else if (ctx.liquid != null) {
-      if (ctx.Str() != null) {
-        return new InsertionNode(insertions.get("include"), visit(ctx.expr()), new AtomNode(strip(ctx.Str().getText())));
+      if (ctx.With() != null) {
+        return new InsertionNode(insertions.get("include"), visit(ctx.expr(0)), visit(ctx.expr(1)));
       } else {
-        return new InsertionNode(insertions.get("include"), visit(ctx.expr()));
+        return new InsertionNode(insertions.get("include"), visit(ctx.expr(0)));
       }
     }
     throw new LiquidException("Unknown syntax of `Include` tag", ctx);

--- a/src/test/java/liqp/parser/v4/LiquidParserTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidParserTest.java
@@ -374,6 +374,16 @@ public class LiquidParserTest {
         );
 
         assertThat(
+                texts("{% include some-file.ext with mu %}", "include_tag", true),
+                equalTo(array("{%", "include", "some-file.ext", "with", "mu", "%}"))
+        );
+
+        assertThat(
+                texts("{% include 'some-file.ext' with 'mu' %}", "include_tag", true),
+                equalTo(array("{%", "include", "'some-file.ext'", "with", "'mu'", "%}"))
+        );
+
+        assertThat(
                 texts("{% include {{variable}} %}", "include_tag", false),
                 equalTo(array("{%", "include", "{{variable}}", "%}"))
         );

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -28,7 +28,9 @@ public class IncludeTest {
                 "{% include 'color' with 'red' %}\n" +
                 "{% include 'color' with 'blue' %}\n" +
                 "{% assign shape = 'square' %}\n" +
-                "{% include 'color' with 'red' %}";
+                "{% include 'color' with 'red' %}\n" +
+                "{%- assign cVar = 'yellow' %}\n" +
+                "{% include 'color' with cVar %}";
 
         Template template = TemplateParser.DEFAULT.parse(source);
 
@@ -43,6 +45,8 @@ public class IncludeTest {
                 "shape: 'circle'\n" +
                 "\n" +
                 "color: 'red'\n" +
+                "shape: 'square'\n" +
+                "color: 'yellow'\n" +
                 "shape: 'square'"));
     }
 
@@ -105,6 +109,23 @@ public class IncludeTest {
         String render = template.render();
 
         assertEquals("color: 'red'\nshape: ''", render);
+    }
+
+    @Test
+    public void renderWithVariableShouldWorkInLiquid() throws RecognitionException {
+        TemplateParser parser = new TemplateParser.Builder() //
+                .withFlavor(Flavor.LIQUID)
+                .withShowExceptionsFromInclude(true)
+                .withErrorMode(TemplateParser.ErrorMode.STRICT)
+                .build();
+
+        Template template = parser.parse("{% assign c = 'blue' %}{% include 'color' with c %}");
+        String render = template.render();
+        assertEquals("color: 'blue'\nshape: ''", render);
+
+        template = parser.parse("{% include 'color' with theme.color %}");
+        render = template.render("{ \"theme\": {\"color\": \"orange\"}}");
+        assertEquals("color: 'orange'\nshape: ''", render);
     }
 
     @Test


### PR DESCRIPTION
* Only String literals were permitted as parameter of include with "with", e.g. `{% include 'snippet' with 'red' %}`
* Now it is possible to reference objects (variables): `{% include 'snippet' with color %}`
* Confirmed with the [reference](https://github.com/Shopify/liquid) Liquid/Ruby implementation
