### PR TITLE
Improved parsing of flavor-specific tag 'include_relative'

### DIFF
--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -58,7 +58,7 @@ public class Template {
         Set<String> tagNames = this.templateParser.insertions.getTagNames();
 
         this.templateSize = stream.size();
-        LiquidLexer lexer = new LiquidLexer(stream, this.templateParser.isStripSpacesAroundTags(),
+        LiquidLexer lexer = new LiquidLexer(stream, this.templateParser.liquidStyleInclude, this.templateParser.isStripSpacesAroundTags(),
                 this.templateParser.isStripSingleLine(), blockNames, tagNames);
         this.sourceLocation = location;
         try {

--- a/src/test/java/liqp/TestUtils.java
+++ b/src/test/java/liqp/TestUtils.java
@@ -34,7 +34,7 @@ public final class TestUtils {
     public static LNode getNode(String source, String rule, TemplateParser templateParser)
         throws Exception {
 
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString("{{ " + source + " }}"));
+        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString("{{ " + source + " }}"), templateParser.liquidStyleInclude, templateParser.stripSpacesAroundTags);
         LiquidParser parser = new LiquidParser(new CommonTokenStream(lexer), templateParser.liquidStyleInclude, templateParser.evaluateInOutputTag, templateParser.errorMode);
 
         LiquidParser.OutputContext root = parser.output();

--- a/src/test/java/liqp/parser/v4/LiquidLexerTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidLexerTest.java
@@ -493,6 +493,23 @@ public class LiquidLexerTest {
         assertThat(tokenise("{%include").get(1).getType(), is(LiquidLexer.Include));
     }
 
+    // IncludeRelative : 'include_relative' { conditional };
+    @Test
+    public void testIncludeRelative() {
+        assertThat("tag 'include_relative' is defined only in Jekyll style",
+            tokenise("{%include_relative").get(1).getType(), is(LiquidLexer.InvalidTagId));
+    }
+
+    @Test
+    public void testIncludeRelativeCustomTag() {
+        HashSet<String> tags = new HashSet<>();
+        tags.add("include_relative");
+        List<Token> tokens = tokenise("{%include_relative%}", new HashSet<String>(), tags);
+
+        assertThat("Custom tag or block 'include_relative' can be defined in Liquid style",
+            tokens.get(1).getType(), is(LiquidLexer.SimpleTagId));
+    }
+
     //   With         : 'with';
     @Test
     public void testWith() {
@@ -598,26 +615,9 @@ public class LiquidLexerTest {
         return tokens;
     }
 
-    static CommonTokenStream commonTokenStream(String source) {
-        return commonTokenStream(source, false);
-    }
-
     static CommonTokenStream commonTokenStream(String source, boolean stripSpacesAroundTags, Set<String> blocks, Set<String> tags) {
-
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(source), stripSpacesAroundTags, blocks, tags);
-
-        lexer.addErrorListener(new BaseErrorListener(){
-            @Override
-            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new RuntimeException(e);
-            }
-        });
-
-        return new CommonTokenStream(lexer);
-    }
-
-    static CommonTokenStream commonTokenStream(String source, boolean stripSpacesAroundTags) {
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(source), stripSpacesAroundTags);
+        boolean isLiquidStyleInclude = true; // No tests for Jekyll style of includes, yet
+        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(source), isLiquidStyleInclude, stripSpacesAroundTags, blocks, tags);
 
         lexer.addErrorListener(new BaseErrorListener(){
             @Override
@@ -628,4 +628,5 @@ public class LiquidLexerTest {
 
         return new CommonTokenStream(lexer);
     }
+
 }


### PR DESCRIPTION
* In Jekyll style, I found that 'include_relative' is incorrectly represented as token `SimpleTag`, instead of `IncludeRelative` (as expected in PR #288). Seems to be caused by Lexer action which should be executed only for Liquid style.
* As a consequence, filename components were parsed as separate parameters instead of token file_name_or_output. This behaviour got unnoticed only because all parameters were incorrectly concatenated into one string (_which is my main concern; to be fixed outside of this PR_)
* In Liquid style, tag 'include_relative' has no default implementation (token `InvalidTagId`), but can be defined as a custom block (token `SimpleBlock`) or a tag (`SimpleTag`). Lexer action works correctly for these checks.
* To facilitate flavor-specific lexical analysis, I am adding flag `isLiquidStyleInclude` to `LiquidLexer`; same flag was added to the `LiquidParser` in #196.

@msangel Please let me know if you see a better or simpler solution. I do not work with Jekyll, I am submitting this change as a prerequisite for rendering of custom tags with two or more parameters in Liquid.