### PR TITLE
Fix rendering of custom tags with more than one parameter

### DIFF
--- a/ruby/cases_render_tag.rb
+++ b/ruby/cases_render_tag.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require 'pp'
+require_relative '_helpers.rb'
+
+# pp render({"val" => "here"}, "{{ val }}")
+
+if isJekyll
+  context = jekyllContext("includes_dir" => "cases_variable_inside_import/_includes")
+  # Tag 'render' is not defined in Jekyll. Use 'include' or 'include_relative'
+  assertRaise do
+    assertEqual("TEST", render({}, "{% render color.liquid %}", context))
+  end
+else
+  Liquid::Template.file_system = Liquid::LocalFileSystem.new("cases_variable_inside_import/_includes", "%s.liquid")
+
+  # liquid template name must be a quoted string
+  assertRaise do
+    assertEqual("there", render({"var" => "there", "tmpl" => "include_read_var"}, "{% render tmpl %}"))
+  end
+  # render variables
+  assertEqual("", render({"var" => "there"}, "{% render 'include_read_var' %}"))
+  assertEqual("here", render({"var" => "there"}, "{% render 'include_read_var', var: 'here' %}"))
+  assertEqual("there", render({"var" => "there"}, "{% render 'include_read_var', var: var %}"))
+  assertEqual("color: ''", render({"color" => "red"}, "{% render 'color' %}"))
+  assertEqual("color: 'blue'", render({"color" => "red"}, "{% render 'color', color: 'blue' %}"))
+  assertEqual("color: 'red'", render({"color" => "red"}, "{% render 'color', color: color %}"))
+  # render with
+  assertEqual("color: 'red'", render({"var" => "there"}, "{% render 'color' with 'red' %}"))
+  assertEqual("color: 'red'", render({"var" => "there"}, "{% render 'color' with 'red', color: 'blue' %}"))
+  assertEqual("color: 'blue'", render({"clr" => "blue"}, "{% render 'color' with clr %}"))
+  assertEqual("color: 'blue'", render({"clr" => "blue"}, "{% render 'color' with clr, color: 'green' %}"))
+  # render for
+  assertEqual("color: 'r'color: 'g'color: 'b'", render({"colors" => ["r", "g", "b"]}, "{% render 'color' for colors %}"))
+  assertEqual("rgb", render({"colors" => ["r", "g", "b"]}, "{% render 'include_read_var' for colors as var %}"))
+  assertEqual("foofoofoo", render({"colors" => ["r", "g", "b"]}, "{% render 'include_read_var' for colors as clr, var: 'foo' %}"))
+end
+

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -58,7 +58,7 @@ public class Template {
         Set<String> tagNames = this.templateParser.insertions.getTagNames();
 
         this.templateSize = stream.size();
-        LiquidLexer lexer = new LiquidLexer(stream, this.templateParser.isStripSpacesAroundTags(),
+        LiquidLexer lexer = new LiquidLexer(stream, this.templateParser.liquidStyleInclude, this.templateParser.isStripSpacesAroundTags(),
                 this.templateParser.isStripSingleLine(), blockNames, tagNames);
         this.sourceLocation = location;
         try {

--- a/src/main/java/liqp/parser/v4/NodeVisitor.java
+++ b/src/main/java/liqp/parser/v4/NodeVisitor.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import liquid.parser.v4.LiquidParser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 import liqp.Insertion;
@@ -194,9 +195,10 @@ public class NodeVisitor extends LiquidParserBaseVisitor<LNode> {
     List<LNode> expressions = new ArrayList<LNode>();
 
     if (ctx.other_tag_parameters() != null) {
-      expressions.add(new AtomNode(ctx.other_tag_parameters().getText()));
+      for (ParseTree child : ctx.other_tag_parameters().other_than_tag_end().children) {
+        expressions.add(new AtomNode(child.getText()));
+      }
     }
-
     return new InsertionNode(insertions.get(ctx.SimpleTagId().getText()), expressions.toArray(new LNode[expressions.size()]));
   }
 

--- a/src/test/java/liqp/InsertionTest.java
+++ b/src/test/java/liqp/InsertionTest.java
@@ -79,6 +79,24 @@ public class InsertionTest {
     }
 
     @Test
+    public void testCustomTagParameters() throws RecognitionException {
+
+        TemplateParser parser = new TemplateParser.Builder().withTag(new Tag("multiply") {
+            @Override
+            public Object render(TemplateContext context, LNode... nodes) {
+                Double number1 = super.asNumber(nodes[0].render(context)).doubleValue();
+                Double number2 = super.asNumber(nodes[1].render(context)).doubleValue();
+                return number1 * number2;
+            }
+        }).build();
+
+        Template template = parser.parse("{% multiply 2 4 %}");
+        String rendered = String.valueOf(template.render());
+
+        assertThat(rendered, is("8.0"));
+    }
+
+    @Test
     public void testCustomTagBlock() throws RecognitionException {
         TemplateParser templateParser = new TemplateParser.Builder().withBlock(new Block("twice") {
             @Override

--- a/src/test/java/liqp/TestUtils.java
+++ b/src/test/java/liqp/TestUtils.java
@@ -34,7 +34,7 @@ public final class TestUtils {
     public static LNode getNode(String source, String rule, TemplateParser templateParser)
         throws Exception {
 
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString("{{ " + source + " }}"));
+        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString("{{ " + source + " }}"), templateParser.liquidStyleInclude, templateParser.stripSpacesAroundTags);
         LiquidParser parser = new LiquidParser(new CommonTokenStream(lexer), templateParser.liquidStyleInclude, templateParser.evaluateInOutputTag, templateParser.errorMode);
 
         LiquidParser.OutputContext root = parser.output();

--- a/src/test/java/liqp/parser/v4/LiquidLexerTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidLexerTest.java
@@ -493,6 +493,23 @@ public class LiquidLexerTest {
         assertThat(tokenise("{%include").get(1).getType(), is(LiquidLexer.Include));
     }
 
+    // IncludeRelative : 'include_relative' { conditional };
+    @Test
+    public void testIncludeRelative() {
+        assertThat("tag 'include_relative' is defined only in Jekyll style",
+            tokenise("{%include_relative").get(1).getType(), is(LiquidLexer.InvalidTagId));
+    }
+
+    @Test
+    public void testIncludeRelativeCustomTag() {
+        HashSet<String> tags = new HashSet<>();
+        tags.add("include_relative");
+        List<Token> tokens = tokenise("{%include_relative%}", new HashSet<String>(), tags);
+
+        assertThat("Custom tag or block 'include_relative' can be defined in Liquid style",
+            tokens.get(1).getType(), is(LiquidLexer.SimpleTagId));
+    }
+
     //   With         : 'with';
     @Test
     public void testWith() {
@@ -598,26 +615,9 @@ public class LiquidLexerTest {
         return tokens;
     }
 
-    static CommonTokenStream commonTokenStream(String source) {
-        return commonTokenStream(source, false);
-    }
-
     static CommonTokenStream commonTokenStream(String source, boolean stripSpacesAroundTags, Set<String> blocks, Set<String> tags) {
-
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(source), stripSpacesAroundTags, blocks, tags);
-
-        lexer.addErrorListener(new BaseErrorListener(){
-            @Override
-            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-                throw new RuntimeException(e);
-            }
-        });
-
-        return new CommonTokenStream(lexer);
-    }
-
-    static CommonTokenStream commonTokenStream(String source, boolean stripSpacesAroundTags) {
-        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(source), stripSpacesAroundTags);
+        boolean isLiquidStyleInclude = true; // No tests for Jekyll style of includes, yet
+        LiquidLexer lexer = new LiquidLexer(CharStreams.fromString(source), isLiquidStyleInclude, stripSpacesAroundTags, blocks, tags);
 
         lexer.addErrorListener(new BaseErrorListener(){
             @Override
@@ -628,4 +628,5 @@ public class LiquidLexerTest {
 
         return new CommonTokenStream(lexer);
     }
+
 }

--- a/src/test/java/liqp/parser/v4/LiquidParserTest.java
+++ b/src/test/java/liqp/parser/v4/LiquidParserTest.java
@@ -68,6 +68,19 @@ public class LiquidParserTest {
         );
 
         assertThat(
+                "tag parameters are concatenated into one String by texts()",
+                texts("{% mu for foo as bar %}", "simple_tag", emptySet, muSet),
+                equalTo(array("{%", "mu", "forfooasbar", "%}"))
+        );
+
+        ParseTree tree = parse("{% mu for foo as bar %}", "simple_tag", emptySet, muSet);
+        assertThat(
+                "tag parameters are parsed as separate nodes",
+                texts(tree.getChild(2).getChild(0)),
+                equalTo(array("for", "foo", "as", "bar"))
+        );
+
+        assertThat(
                 texts("{% mu %} . {% endmu %}", "other_tag", muSet, emptySet),
                 equalTo(array("{%", "mu", "%}", " . ", "{%", "endmu", "%}"))
         );


### PR DESCRIPTION
Trying to add moderately complex custom tags, I encountered a problem:
* All tag parameters were concatenated into one string, e.g. `{% mu for foo as bar %}` was presented as one node `["forfooasbar"]` in Tag method `render(context, nodes)`
* Caused by combining text of all children of token 'other_tag_parameters' in `NodeVisitor.visitSimple_tag()`
Implementation was changed in #227. I reviewed the related tickets and didn't find justification for the concatenation
* This PR separates each parameter to a distinct node, i.e. `["for", "foo", "as", "bar"]`

I am focused on the Liquid flavor, but the change should work well for Jekyll as well.
There was one Jekyll scenario with failing tests, revealing an unrelated problem with parsing of `include_relative`. I submitted #300 as a prerequisite of this PR.

@msangel I'd appreciate your insight. I'm wondering if there was a reason for such string concatenation in #227 I am not aware of?

For reference, the original pre-227 code: 
``` java
public BlockNode visitOther_tag_block(Other_tag_blockContext ctx) {
    BlockNode node = new BlockNode(isRootBlock);
    for (AtomContext child : ctx.atom()) {
      node.add(visit(child));
    }
    return node;
  }
``` 

cc @bkiers 