### PR TITLE
update map string parse in blockNode asString()

### DIFF
--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -5,6 +5,8 @@ import liqp.TemplateContext;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static liqp.LValue.BREAK;
 import static liqp.LValue.CONTINUE;
@@ -78,6 +80,20 @@ public class BlockNode implements LNode {
         if (isTemporal(value)) {
             ZonedDateTime time = asTemporal(value, context);
             return rubyDateTimeFormat.format(time);
+        } else {
+            return getValueAsString(value);
+        }
+    }
+
+    private String mapToString(Map<Object, Object> map) {
+        return map.entrySet().stream()
+                .map(entry -> entry.getKey() + ": " + getValueAsString(entry.getValue()))
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    private String getValueAsString(Object value) {
+        if (value instanceof Map) {
+            return mapToString((Map<Object, Object>) value);
         } else {
             return String.valueOf(value);
         }


### PR DESCRIPTION
BlockNode render uses "String.valueOf(object)" to convert the object to String.

in case of HashMap<Object, Object> mapObject, String.valueOf(mapObject) doesn't return an appropriate String.

For example:
String.valueOf(mapObject) will give '=' instead of ':' as the delimiter which:
1.  doesn't look pretty as we say in pretty print.
2. it's not easy to decode while reading.

So, merging this PR will help us and other devs.

After this PR, the mapObject will look something like below:
1. {name: {first-name: test-first-name, last-name: test-last-name}}
vs current output: {name={first-name=test-first-name, last-name=test-last-name}}


2. {address: {area: bellandur, flat: a-1234, contact: {alternate contact: 12341234, contact: 9898989898}}, name: {first-name: test-first-name, last-name: test-last-name}}
4. {name: {nos2: [25, 1254], nos1: [25, 1254]}}

the above 3 sample output is what I got when I am trying to render root element of the HashMap <?, ?> -> output provides all the keys and corresponding values.

I took a fork from tag: 0.8.3.3