### PR TITLE
Fix performance issue w.r.t. not_out_end

### DIFF
--- a/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidLexer.g4
@@ -104,6 +104,7 @@ fragment LineBreak      : '\r'? '\n' | '\r';
 fragment Letter         : [a-zA-Z];
 fragment Digit          : [0-9];
 
+// Note that when adding tokens to this `IN_TAG` mode, be sure to include them in the parser rule `not_out_end` as well!
 mode IN_TAG;
 
   OutStart2 : '{{' -> pushMode(IN_TAG);

--- a/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
+++ b/src/main/antlr4/liquid/parser/v4/LiquidParser.g4
@@ -230,8 +230,19 @@ output
  | {isWarn() || isLax()}? outStart term filter* unparsed=not_out_end? OutEnd
  ;
 
+// When doing `( ~OutEnd )+`, it appears ANTLR is much slower on large input text. Even when `isStrict() == true` the
+// parser will never get here, but the prediction algorithm still tries this branch and takes too much time when the
+// much too large set `( ~OutEnd )+` is used. The tokens below are all tokens that are possible when the lexer is in
+// the `IN_TAG` mode.
+//
+// The input from https://github.com/bkiers/Liqp/issues/310 is tested by parsing it 100 times. When this rule contains
+// `( ~OutEnd )+`, it ran in about 8000-8500 ms on average. With the individual tokens specified in the `IN_TAG` mode,
+// the average runtime was around 3000-3200 ms.
 not_out_end
- : ( ~OutEnd )+
+ : ( OutStart2 | TagEnd | Str | DotDot | Dot | NEq | Eq | EqSign | GtEq | Gt | LtEq | Lt | Minus | Pipe
+   | Col | Comma | OPar | CPar | OBr | CBr | QMark | PathSep | DoubleNum | LongNum | Contains | In | And
+   | Or | True | False | Nil | With | Offset | Continue | Reversed | Empty | Blank | IdChain | Id
+   )+
  ;
 
 filter


### PR DESCRIPTION
Fixes #310 

I tested this by adding `./src/test/test.liquid`  with the contents from the issue #310 (https://github.com/user-attachments/files/17264247/test_template_string.txt)

```java
public class PerfTest {

    @Test
    public void test() throws Exception {
        int repeat = 100;
        long start = System.currentTimeMillis();

        TemplateParser templateParser = new TemplateParser.Builder().build();

        for (int i = 0; i < repeat; i++) {
            templateParser.parse(new File("./src/test/test.liquid"));
        }

        System.out.printf("%d ms.", System.currentTimeMillis() - start);
    }
}
```

when `not_out_end` was:

```
not_out_end
 : ( ~OutEnd )+
 ;
```

the test ran in around 8000-8500 ms. With the changes in this PR the test ran in around 3000-3200 ms.