### PR TITLE
Add more date patterns and changed to a more lenient day and month parsing

### DIFF
--- a/src/main/java/liqp/filters/date/Parser.java
+++ b/src/main/java/liqp/filters/date/Parser.java
@@ -6,9 +6,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 import static java.time.temporal.ChronoField.*;
 import static java.time.temporal.ChronoField.INSTANT_SECONDS;
@@ -29,78 +27,132 @@ public class Parser {
      */
     public static List<String> datePatterns = new ArrayList<>();
 
+    // Since Liquid supports dates like `March 1st`, this list will
+    // hold strings that will be removed from the input string.
+    private static final String[] toBeRemoved = new String[] { "st", "nd", "rd", "th" };
+
     static {
 
-        datePatterns.add("EEE MMM dd hh:mm:ss yyyy");
-        datePatterns.add("EEE MMM dd hh:mm yyyy");
-        datePatterns.add("yyyy-MM-dd");
-        datePatterns.add("dd-MM-yyyy");
+        datePatterns.add("EEE MMM d hh:mm:ss yyyy");
+        datePatterns.add("EEE MMM d hh:mm yyyy");
+        datePatterns.add("yyyy-M-d");
+        datePatterns.add("d-M-yyyy");
+        datePatterns.add("d-M-yy");
+        datePatterns.add("yy-M-d");
+
+        datePatterns.add("d/M/yyyy");
+        datePatterns.add("yyyy/M/d");
+        datePatterns.add("d/M/yy");
+        datePatterns.add("yy/M/d");
+        datePatterns.add("M/yyyy");
+        datePatterns.add("yyyy/M");
+        datePatterns.add("M/d");
+        datePatterns.add("d/M");
 
         // this is section without `T`, change here and do same change in section below with `T`
-        datePatterns.add("yyyy-MM-dd HH:mm");
-        datePatterns.add("yyyy-MM-dd HH:mm X");
-        datePatterns.add("yyyy-MM-dd HH:mm Z");
-        datePatterns.add("yyyy-MM-dd HH:mm z");
-        datePatterns.add("yyyy-MM-dd HH:mm'Z'");
+        datePatterns.add("yyyy-M-d HH:mm");
+        datePatterns.add("yyyy-M-d HH:mm X");
+        datePatterns.add("yyyy-M-d HH:mm Z");
+        datePatterns.add("yyyy-M-d HH:mm z");
+        datePatterns.add("yyyy-M-d HH:mm'Z'");
 
-        datePatterns.add("yyyy-MM-dd HH:mm:ss");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss X");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss Z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss'Z'");
+        datePatterns.add("yyyy-M-d HH:mm:ss");
+        datePatterns.add("yyyy-M-d HH:mm:ss X");
+        datePatterns.add("yyyy-M-d HH:mm:ss Z");
+        datePatterns.add("yyyy-M-d HH:mm:ss z");
+        datePatterns.add("yyyy-M-d HH:mm:ss'Z'");
 
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSS");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSS X");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSS Z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSS z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSS'Z'");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSS");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSS X");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSS Z");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSS z");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSS'Z'");
 
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSS");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSS X");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSS Z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSS z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSS'Z'");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSS");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSS X");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSS Z");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSS z");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSS'Z'");
 
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSSSSS");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSSSSS X");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSSSSS Z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSSSSS z");
-        datePatterns.add("yyyy-MM-dd HH:mm:ss.SSSSSSSSS'Z'");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSSSSS");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSSSSS X");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSSSSS Z");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSSSSS z");
+        datePatterns.add("yyyy-M-d HH:mm:ss.SSSSSSSSS'Z'");
 
         // this is section with `T`
-        datePatterns.add("yyyy-MM-dd'T'HH:mm");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm X");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm Z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm'Z'");
+        datePatterns.add("yyyy-M-d'T'HH:mm");
+        datePatterns.add("yyyy-M-d'T'HH:mm X");
+        datePatterns.add("yyyy-M-d'T'HH:mm Z");
+        datePatterns.add("yyyy-M-d'T'HH:mm z");
+        datePatterns.add("yyyy-M-d'T'HH:mm'Z'");
 
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss X");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss Z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss X");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss Z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss'Z'");
 
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSS X");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSS Z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSS z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSS");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSS X");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSS Z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSS z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSS'Z'");
 
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSS X");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSS Z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSS z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSS");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSS X");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSS Z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSS z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSS'Z'");
 
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS X");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS Z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS z");
-        datePatterns.add("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSSSSS");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSSSSS X");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSSSSS Z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSSSSS z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ss.SSSSSSSSS'Z'");
 
+        datePatterns.add("EEE MMM d HH:mm:ss yyyy");
+        datePatterns.add("EEE, d MMM yyyy HH:mm:ss Z");
+        datePatterns.add("EEE, d MMM yyyy HH:mm:ss z");
+        datePatterns.add("MMM d HH:mm:ss yyyy");
+        datePatterns.add("d MMM yyyy HH:mm:ss Z");
+        datePatterns.add("d MMM yyyy HH:mm:ss z");
+        datePatterns.add("yyyy-M-d'T'HH:mm:ssXXX");
+
+        datePatterns.add("d MMM");
+        datePatterns.add("d MMM yy");
+        datePatterns.add("d MMM yyyy");
+        datePatterns.add("d MMMM");
+        datePatterns.add("d MMMM yy");
+        datePatterns.add("d MMMM yyyy");
+
+        datePatterns.add("MMM d");
+        datePatterns.add("MMM d, yy");
+        datePatterns.add("MMM d, yyyy");
+
+        datePatterns.add("MMMM d");
+        datePatterns.add("MMMM d, yy");
+        datePatterns.add("MMMM d, yyyy");
+
+        datePatterns.add("MMM");
+        datePatterns.add("MMM yy");
+        datePatterns.add("MMM yyyy");
+
+        datePatterns.add("MMMM");
+        datePatterns.add("MMMM yy");
+        datePatterns.add("MMMM yyyy");
+
+        datePatterns.add("H:mm");
+        datePatterns.add("H:mm:ss");
     }
 
     public static ZonedDateTime parse(String str, Locale locale, ZoneId defaultZone) {
+
+        String normalized = str.toLowerCase();
+
+        for(String value : toBeRemoved) {
+            normalized = normalized.replace(value, "");
+        }
 
         for(String pattern : datePatterns) {
             try {
@@ -110,7 +162,7 @@ public class Parser {
                         .appendPattern(pattern)
                         .toFormatter(locale);
 
-                TemporalAccessor temporalAccessor = timeFormatter.parse(str);
+                TemporalAccessor temporalAccessor = timeFormatter.parse(normalized);
                 return getZonedDateTimeFromTemporalAccessor(temporalAccessor, defaultZone);
             } catch (Exception e) {
                 // ignore


### PR DESCRIPTION
Add more date patterns and changed to a more lenient day and month parsing: `MM` and `dd` changed to `M` and `d`. Now not only things like `2024-02-09` are parsed correctly, but also `2024-2-9`

Fixes #309 